### PR TITLE
Small 1 line change to get things working with edge node as of todays trunk

### DIFF
--- a/lib/log4js.js
+++ b/lib/log4js.js
@@ -362,7 +362,7 @@ function configure (configurationFileOrObject) {
 
 function findConfiguration() {
     //add current directory onto the list of configPaths
-    var paths = ['.'].concat(require.paths);
+    var paths = ['.'].concat(process.env.NODE_PATH);
     //add this module's directory to the end of the list, so that we pick up the default config
     paths.push(__dirname);
     var pathsWithConfig = paths.filter( function (pathToCheck) {


### PR DESCRIPTION
fixed deprecated and removed call to require.paths and replaced with the NODE_PATH env variable
