### PR TITLE
SMTP appender

### DIFF
--- a/lib/appenders/smtp.js
+++ b/lib/appenders/smtp.js
@@ -56,7 +56,7 @@ function smtpAppender(recipients, sender, subject, layout, smtpConfig, sendInter
 	
 	return function(loggingEvent) {
 		logEventBuffer.push(loggingEvent);
-		if (sendInterval)
+		if (sendInterval > 0)
 			scheduleSend();
 		else
 			sendBuffer();


### PR DESCRIPTION
I've added simple SMTP appender, it works fine for me over 2 months. 
It allows to send logging events through SMTP protocol to specified recipients. Uses andris9/Nodemailer library. Logging events may be buffered during specified time and sent in one email, default is one email per event.
