### PR TITLE
Allow appenders to be located outside the log4js directory

### DIFF
--- a/lib/log4js.js
+++ b/lib/log4js.js
@@ -136,7 +136,7 @@ function configureAppenders(appenderList) {
     clearAppenders();
     if (appenderList) {
         appenderList.forEach(function(appenderConfig) {
-            loadAppender(appenderConfig.type);
+            loadAppender(appenderConfig);
             var appender;
             appenderConfig.makers = appenderMakers;
             appender = appenderMakers[appenderConfig.type](appenderConfig);
@@ -364,7 +364,15 @@ function restoreConsole() {
 }
 
 function loadAppender(appender) {
-    var appenderModule = require('./appenders/' + appender);
+    var appenderLocation;
+    if(typeof appender === 'object'){
+        appenderLocation = appender.location || ('./appenders/' + appender.type);
+    } else if(typeof appender === 'string'){
+        appenderLocation = './appenders/' + appender;
+    }
+    
+    var appenderModule = require(appenderLocation);
+    
     module.exports.appenders[appenderModule.name] = appenderModule.appender;
     appenderMakers[appenderModule.name] = appenderModule.configure;
 }


### PR DESCRIPTION
When installing log4js via NPM, it deletes custom appenders. It's also better for organization if we can place them wherever we want and keep them separate from the log4js code.

This pull request adds support for an additional location property on an appender that can be set to specify where the appender resides. The change should be reverse compatible with existing configuration options.
