### PR TITLE
make restoreConsole work

### DIFF
--- a/lib/appenders/console.js
+++ b/lib/appenders/console.js
@@ -1,9 +1,10 @@
-var layouts = require('../layouts');
+var layouts = require('../layouts'),
+    consoleLog = console.log;
 
 function consoleAppender (layout) {
     layout = layout || layouts.colouredLayout;
     return function(loggingEvent) {
-	console._preLog4js_log(layout(loggingEvent));
+	consoleLog(layout(loggingEvent));
     };
 }
 


### PR DESCRIPTION
fix bug #52, by making the console appender not depend on console._preLog4js_log, which restoreConsole removes.

this relies on the fact that the console appender module is require'd by log4js, and so executes before it.

ps: it would be nice if console.log was not replaced by default: it breaks other packages that rely on specific output formatting, eg unit-test frameworks.
