### PR TITLE
Lazy logging.

### DIFF
--- a/lib/layouts.js
+++ b/lib/layouts.js
@@ -50,7 +50,8 @@ function formatLogData(logData) {
         if (item && item.stack) {
             output += item.stack;
         } else {
-            output += util.inspect(item);
+            var useToString = typeof item.toString === "function" && new Object().toString !== item.toString;
+            output += useToString ? item.toString() : util.inspect(item);
         }
     });
 


### PR DESCRIPTION
This improves performance since now one doesn't need
to convert an object to a string before logging it. The
object will be strigified using the toString method (if
implemented) just before being logged. So, if we log an
object with log-level "DEBUG" and the level of the logger
is "INFO", the object will never be stringified -- saving
valuable CPU cycles.
