### PR TITLE
Allow passing cwd (__dirname) as an option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,35 @@ To specify a different period:
 
 You can also pass an object to the configure function, which has the same properties as the json versions.
 
+For FileAppender you can also pass the path to the log directory as an option where all your log files would be stored.
+
+    log4js.configure('my_log4js_configuration.json', { cwd: '/absolute/path/to/log/dir' });
+
+If you have already defined an absolute path for one of the FileAppenders in the configuration file, you could add a "absolute": true to the particular FileAppender to override the cwd option passed. Here is an example configuration file:
+
+    #### my_log4js_configuration.json ####
+    {
+      "appenders": [
+        {
+          "type": "file",
+          "filename": "relative/path/to/log_file.log",
+          "maxLogSize": 20480,
+          "backups": 3,
+          "pollInterval": 15,
+          "category": "relative-logger"
+        },
+        {
+          "type": "file",
+          "absolute": true,
+          "filename": "/absolute/path/to/log_file.log",
+          "maxLogSize": 20480,
+          "backups": 10,
+          "pollInterval": 15,
+          "category": "absolute-logger"          
+        }
+      ]
+    }
+
 ## connect/express logger
 
 A connect/express logger has been added to log4js, by [danbell](https://github.com/danbell). This allows connect/express servers to log using log4js. See example-connect-logger.js.

--- a/lib/log4js.js
+++ b/lib/log4js.js
@@ -325,24 +325,36 @@ function initReloadConfiguration(filename, options) {
 function configure (configurationFileOrObject, options) {
     var config = configurationFileOrObject;
     options = options || {};
-    if (options.hasOwnProperty('cwd')) {
-        config.appenders.forEach(function(appender) {
-            if (appender.hasOwnProperty('filename')) {
-                 appender.filename = options.cwd + '/' + appender.filename;
-            }
-        });
-    }
+
     if (config === undefined || config === null || typeof(config) === 'string') {
         if (options.reloadSecs) {
             initReloadConfiguration(config, options);
         }
-        configureOnceOff(loadConfigurationFile(config));
+        config = loadConfigurationFile(config);
     } else {
         if (options.reloadSecs) {
             getLogger('log4js').warn('Ignoring configuration reload parameter for "object" configuration.');
         }
-        configureOnceOff(config);
     }
+
+    if (options.hasOwnProperty('cwd')) {
+        if(config.hasOwnProperty('appenders')) {
+            config.appenders.forEach(function(appender) {
+                if (!appender.hasOwnProperty('type')) return;
+
+                if (appender.type === 'file') {
+                    if(!appender.hasOwnProperty('filename')) return;
+                    if(appender.hasOwnProperty('absolute')) {
+                        if(appender.absolute) return;
+                    }
+
+                    appender.filename = path.join(options.cwd, appender.filename);
+                }
+            });
+        }
+    }
+
+    configureOnceOff(config);
 }
 
 function replaceConsole(logger) {

--- a/test/test-log-abspath.js
+++ b/test/test-log-abspath.js
@@ -1,0 +1,95 @@
+var vows = require('vows')
+, assert = require('assert')
+, sandbox = require('sandboxed-module');
+
+vows.describe('log4js-abspath').addBatch({
+    'configuration is passed as object with options.cwd': {
+        topic: function() {
+            var appenderConfig
+          , log4js = sandbox.require(
+              '../lib/log4js'
+            , { requires:
+                { './appenders/file':
+                  {
+                      name: "file"
+                    , appender: function() {}
+                    , configure: function(configuration) {
+                          appenderConfig = configuration;
+                          return function() {};
+                      }
+                  }
+                }
+              }
+          )
+          , config = {
+                "appenders": [
+                    {
+                        "type" : "file",
+                        "filename" : "cheesy-wotsits.log",
+                        "maxLogSize" : 1024,
+                        "backups" : 3,
+                        "pollInterval" : 15
+                    }
+                ]
+            };
+            log4js.configure(config, {
+                cwd: '/absolute/path/to'
+            });
+            return appenderConfig;
+        },
+        'should be an absolute path': function(configuration) {
+            assert.equal(configuration.filename, '/absolute/path/to/cheesy-wotsits.log');
+        }
+    },
+
+    'configuration passed as filename with options.cwd': {
+        topic: function() {
+            var appenderConfig
+          , configFilename
+          , log4js = sandbox.require(
+                '../lib/log4js'
+              , { requires:
+                  { 'fs':
+                    {
+                        statSync: function() {
+                            return { mtime: Date.now() };
+                        },
+                        readFileSync: function(filename) {
+                            configFilename = filename;
+                            return JSON.stringify({
+                                appenders: [
+                                    { type: "file"
+                                    , filename: "whatever.log"
+                                    }
+                                ]
+                            });
+                        },
+                        readdirSync: function() {
+                            return ['file'];
+                        }
+                    }
+                , './appenders/file':
+                    {
+                      name: "file"
+                    , appender: function() {}
+                    , configure: function(configuration) {
+                          appenderConfig = configuration;
+                          return function() {};
+                      }
+                    }
+                  }
+                }
+          );
+            log4js.configure("/path/to/cheese.json", {
+                cwd: '/absolute/path/to'
+            });
+            return [ configFilename, appenderConfig ];
+        },
+        'should read the config from a file': function(args) {
+            assert.equal(args[0], '/path/to/cheese.json');
+        },
+        'should be an absolute path': function(args) {
+            assert.equal(args[1].filename, "/absolute/path/to/whatever.log");
+        }
+    },
+}).export(module);


### PR DESCRIPTION
Ex:

```
    log4js.configure('relative/path/to/config/file.json', {
        cwd: __dirname
    });
    log4js.addAppender(log4js.consoleAppender());
```
