### PR TITLE
Make output mechanism configurable for the console logger.

### DIFF
--- a/lib/appenders/console.js
+++ b/lib/appenders/console.js
@@ -13,6 +13,9 @@ function configure(config) {
     if (config.layout) {
 	layout = layouts.layout(config.layout.type, config.layout);
     }
+    if (config.writer) {
+	consoleLog = config.writer;
+    }
     return consoleAppender(layout);
 }
 


### PR DESCRIPTION
Another try at issue #66.  This keeps the existing behavior the default, but allows me to set the output to stderr pretty easily using:

```
log4js.appenderMakers['console']({"writer": console.warn})
```
