### PR TITLE
Add line + column number to each log line

### DIFF
--- a/lib/log4js.js
+++ b/lib/log4js.js
@@ -203,9 +203,15 @@ Logger.prototype.removeLevel = function() {
 };
 
 Logger.prototype.log = function() {
+    var location = new Error().stack.split('\n')[3].match(/:([0-9]+):([0-9]+)\)$/);
+    var category = this.category;
+    if (location) {
+        category += ':' + location[1] + ':' + location[2];
+    }
+
     var args = Array.prototype.slice.call(arguments)
-  , logLevel = args.shift()
-  , loggingEvent = new LoggingEvent(this.category, logLevel, args, this);
+    , logLevel = args.shift()
+    , loggingEvent = new LoggingEvent(category, logLevel, args, this);
     this.emit("log", loggingEvent);
 };
 


### PR DESCRIPTION
I think log lines should contain a line + column number so that debugging issues becomes easier. You no longer need to identify a log line with some sort of unique identifier if line numbers are present.
