### PR TITLE
fix bug - log4js.json is not recognized in execution folder

### DIFF
--- a/lib/log4js.js
+++ b/lib/log4js.js
@@ -252,7 +252,7 @@ function findConfiguration(filename) {
                 || filename.indexOf(":") == -1 //not absolute on windows
                 ) 
             filename = process.cwd() + "/" + filename;
-        path = filename;
+        path = require.resolve(filename);
     } catch (e) {
         //file not found. default to the one in the log4js module.
         path = filename || __dirname + '/log4js.json';


### PR DESCRIPTION
Just placing the log4js on the execution folder does not work out of the box - it falls back to 

```
/node_modules/log4js/lib/log4js.js 
```

because `require.resolve()` is relative to the current-executing-script.

The suggested patch uses process.cwd() to determine the execution folder.
