### PR TITLE
try 2

### DIFF
--- a/lib/log4js.js
+++ b/lib/log4js.js
@@ -245,13 +245,18 @@ function getDefaultLogger () {
 
 function findConfiguration(filename) {
     var path;
-    try {
-        path = require.resolve(process.cwd() + "/" + (filename || 'log4js.json'));
+    try { 
+        if (!filename) 
+            filename = 'log4js.json';
+        else if (  filename.charAt(0) != '/'   //not absolute on *n*x
+                || filename.indexOf(":") == -1 //not absolute on windows
+                ) 
+            filename = process.cwd() + "/" + filename;
+        path = filename;
     } catch (e) {
         //file not found. default to the one in the log4js module.
         path = filename || __dirname + '/log4js.json';
     }
-
     return path;
 }
 


### PR DESCRIPTION
... box - it falls back to /node_modules/log4js/lib/log4js.js because require.resolve() is relative to the current-executing-script.
