### PR TITLE
log4js.json is not recognized in root folder

### DIFF
--- a/lib/log4js.js
+++ b/lib/log4js.js
@@ -244,18 +244,18 @@ function getDefaultLogger () {
 }
 
 function findConfiguration(filename) {
-    var sPath = filename || 'log4js.json';
+    var path = filename || 'log4js.json';
     try { 
-        if (  sPath.charAt(0) != '/'   //not absolute on *n*x
-           || sPath.indexOf(":") == -1 //not absolute on windows
+        if (  path.charAt(0) != '/'   //not absolute on *n*x
+           || path.indexOf(":") == -1 //not absolute on windows
             ) 
-            sPath = path.join( process.cwd(), sPath || "log4js.json");
-        sPath = require.resolve(path);
+            path = process.cwd() + "/" + (path || "log4js.json");
+        path = require.resolve(path);
     } catch (e) {
         //file not found. default to the one in the log4js module.
-        sPath = filename || path.join( __dirname , 'log4js.json');
+        path = filename || __dirname + '/log4js.json';
     }
-    return sPath;
+    return path;
 }
 
 


### PR DESCRIPTION
The suggested fix was tested against the following cases:
- when absolute path to configuration is used - it is tried.
- when relative path is found - it is considered relative to execution directory.
- when no path is provided - try to load `log4js.json` from execution directory.
- when tried file path does not resolve to a file - `__dirname + "/log4js.json"` is used.

NOTE: `__dirname + "/log4js.json"` will **always** provide the default log4js.json from the log4js module.
I would advise to move it from ./lib to something like ./config, or ./sample, but that's up to you :)

I did not update the test suite. If you tell me how you run it - I'll do that too in an additional pull request :)
