### PR TITLE
Speed up file logging for high rate of logging.

### DIFF
--- a/lib/streams/BufferedWriteStream.js
+++ b/lib/streams/BufferedWriteStream.js
@@ -1,4 +1,5 @@
 var events = require('events'),
+    Dequeue = require('dequeue'),
     util = require('util');
 
 module.exports = BufferedWriteStream;
@@ -6,7 +7,7 @@ module.exports = BufferedWriteStream;
 function BufferedWriteStream(stream) {
     var that = this;
     this.stream = stream;
-    this.buffer = [];
+    this.buffer = new Dequeue();
     this.canWrite = false;
     this.bytes = 0;
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
        "lib": "lib"
    },
    "dependencies": {
-       "async": "0.1.15"
+       "async": "0.1.15",
+       "dequeue": "1.0.3"
    },
    "devDependencies": {
        "vows": "0.6.2",


### PR DESCRIPTION
This is in response to my own https://github.com/nomiddlename/log4js-node/issues/114.

During an evaluation of multiple loggers, I saw a slow down when trying to
quickly log more than 100,000 messages to a file:

``` javascript
    counter = 150000;
    while (counter) {
        logger.info('Message[' + counter + ']');
        counter -= 1;
    }
```

My detailed test can be found here:
- https://gist.github.com/NicolasPelletier/4773843

The test demonstrate that writing 150,000 lines straight in a FileStream
takes about 22 seconds until the file content stabilizes. When calling
logger.debug() 150,000 times, the file stabilizes to its final content
after 229s ( almost 4 minutes ! ).

After investigation, it turns out that the problem is using an Array() to
accumulate the data. Pushing the data in the Array with Array.push() is
quick, but the code flushing the buffer uses Array.shift(), which forces
re-indexing of all 149,999 elements remaining in the Array. This is
exponentially slower as the buffer grows.

The solution is to use something else than an Array to accumulate the
messages. The fix was made using a package called Dequeue
( https://github.com/lleo/node-dequeue ). By replacing the Array with
a Dequeue object, it brought the logging of 150,000 messages back down to
31s. Seven times faster than the previous 229s.

There is a caveat that each log event is slightly longer due to the need
to create an object to put in the double-ended queue inside the Dequeue
object. According to a quick test, it takes about 4% more time per call
to logger.debug().
