### PR TITLE
Pass options from multiprocess appender to inner appender

### DIFF
--- a/lib/appenders/multiprocess.js
+++ b/lib/appenders/multiprocess.js
@@ -115,11 +115,11 @@ function createAppender(config) {
     }
 }
 
-function configure(config) {
+function configure(config, options) {
     var actualAppender;
     if (config.appender && config.mode === 'master') {
         log4js.loadAppender(config.appender.type);
-        actualAppender = log4js.appenderMakers[config.appender.type](config.appender);
+        actualAppender = log4js.appenderMakers[config.appender.type](config.appender, options);
         config.actualAppender = actualAppender;
     }
     return createAppender(config);


### PR DESCRIPTION
If you use multiprocess with an inner appender (say 'file' type),
you are not able to pass options to the that inner appender.
For instance, in the example below cwd is not visible to 'file'.

```
log4js.configure({
    type: 'multiprocess',
    mode: 'master',
    appender: {
      type: 'file',
      ...
    }
  }, {
    cwd: 'whatever'
  });
```

This patch hopefully fixes that bug.

I would be happy if you could pull it into master.
Thank you in advance.
