### PR TITLE
Allow for somewhat standard debugging calls

### DIFF
--- a/lib/streams/BaseRollingFileStream.js
+++ b/lib/streams/BaseRollingFileStream.js
@@ -2,8 +2,11 @@ var fs = require('fs'),
 stream = require('stream'),
 util = require('util');
 
-function debug(message) {
-//    console.log(message);
+var debug;
+if (process.env.NODE_DEBUG && /\blog4js\b/.test(process.env.NODE_DEBUG)) {
+    debug = function(message) { console.error('LOG4JS: (BaseRollingFileStream) %s', message); };
+} else {
+    debug = function() { };
 }
 
 module.exports = BaseRollingFileStream;

--- a/lib/streams/DateRollingFileStream.js
+++ b/lib/streams/DateRollingFileStream.js
@@ -6,8 +6,11 @@ var BaseRollingFileStream = require('./BaseRollingFileStream'),
 
 module.exports = DateRollingFileStream;
 
-function debug(message) {
-//    console.log(message);
+var debug;
+if (process.env.NODE_DEBUG && /\blog4js\b/.test(process.env.NODE_DEBUG)) {
+    debug = function(message) { console.error('LOG4JS: (DateRollingFileStream) %s', message); };
+} else {
+    debug = function() { };
 }
 
 function DateRollingFileStream(filename, pattern, options, now) {

--- a/lib/streams/RollingFileStream.js
+++ b/lib/streams/RollingFileStream.js
@@ -4,9 +4,11 @@ var BaseRollingFileStream = require('./BaseRollingFileStream'),
     fs = require('fs'),
     async = require('async');
 
-function debug() {
-//    util.debug(message);
-//  console.log.apply(console, arguments);
+var debug;
+if (process.env.NODE_DEBUG && /\blog4js\b/.test(process.env.NODE_DEBUG)) {
+    debug = function(message) { console.error('LOG4JS: (RollingFileStream) %s', message); };
+} else {
+    debug = function() { };
 }
 
 module.exports = RollingFileStream;


### PR DESCRIPTION
Rather than commenting out `console.log` messages or whatever, this would allow for debugging messages in much the same way as node core.

For example:

`NODE_DEBUG="http,log4js" node myapp.js`
