### PR TITLE
Fix node engine in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
    "bugs": {
        "url": "http://github.com/nomiddlename/log4js-node/issues"
    },
-   "engines": [ "node >=0.10" ],
+   "engines": {
+     "node": ">=0.10"
+   },
    "scripts": {
        "test": "vows"
    },


### PR DESCRIPTION
This is the correct specification of the node engine, otherwise it gets ignored by npm. Please also fix this in the `0.5.7` version so we can do installs depending on the node version.
