### PR TITLE
Fixes bug in detecting empty options (see issue #132 on github)

### DIFF
--- a/lib/streams/DateRollingFileStream.js
+++ b/lib/streams/DateRollingFileStream.js
@@ -30,7 +30,7 @@ function DateRollingFileStream(filename, pattern, options, now) {
       filename = filename + this.lastTimeWeWroteSomething;
     }
     delete options.alwaysIncludePattern;
-    if (options === {}) { 
+    if (Object.keys(options).length === 0) { 
       options = null; 
     }
   }

--- a/test/dateFileAppender-test.js
+++ b/test/dateFileAppender-test.js
@@ -113,6 +113,7 @@ vows.describe('../lib/appenders/dateFile').addBatch({
 		      ]
 		    }
 	      , thisTime = format.asString(options.appenders[0].pattern, new Date());
+	      fs.writeFileSync(path.join(__dirname, 'date-file-test' + thisTime), "this is existing data" + require('os').EOL, 'utf8');
 	      log4js.clearAppenders();
 	      log4js.configure(options);
 	      logger = log4js.getLogger('tests');
@@ -122,6 +123,9 @@ vows.describe('../lib/appenders/dateFile').addBatch({
 	    },
 	    'should create file with the correct pattern': function(contents) {
 	      assert.include(contents, 'this should be written to the file with the appended date');
+	    },
+	    'should not overwrite the file on open (bug found in issue #132)': function(contents) {
+	      assert.include(contents, 'this is existing data');
 	    }
 	  }
       


### PR DESCRIPTION
In issue #132, a bug was introduced in that (options === {}) was never matching, and causing us to call the superclass constructor with {} instead of null.  This, in turn, nuked the default stream options.

This pull request tests for a symptom of the above (whether or not 'a' is in the file mode) and fixes the check for empty options in the sub-class
