### PR TITLE
Add custom field support to GELF appender

### DIFF
--- a/lib/appenders/gelf.js
+++ b/lib/appenders/gelf.js
@@ -43,7 +43,6 @@ function gelfAppender (layout, host, port, hostname, facility, customFields) {
   layout = layout || layouts.messagePassThroughLayout;
 
   var defaultCustomFields = customFields || {};
-  console.log(defaultCustomFields)
   
   var client = dgram.createSocket("udp4");
   

--- a/test/gelfAppender-test.js
+++ b/test/gelfAppender-test.js
@@ -135,5 +135,51 @@ vows.describe('log4js gelfAppender').addBatch({
         assert.equal(message.facility, 'nonsense');
       }
     }
+  },
+  'with custom fields options': {
+    topic: function() {
+      var setup = setupLogging({
+        host: 'somewhere',
+        port: 12345,
+        hostname: 'cheese',
+        facility: 'nonsense',
+        customFields: {
+            _every1: 'Hello every one',
+            _every2: 'Hello every two'
+        }
+      });
+      var myFields = {
+          GELF: true,
+          _every2: 'Overwritten!',
+          _myField: 'This is my field!'
+      };
+      setup.logger.debug(myFields, "Just testing.");
+      return setup;
+    },
+    'the dgram packet': {
+      topic: function(setup) {
+        return setup.dgram;
+      },
+      'should pick up the options': function(dgram) {
+        assert.equal(dgram.socket.host, 'somewhere');
+        assert.equal(dgram.socket.port, 12345);
+      }
+    },
+    'the uncompressed packet': {
+      topic: function(setup) {
+        var message = JSON.parse(setup.compress.uncompressed);
+        return message;
+      },
+      'should pick up the options': function(message) {
+        assert.equal(message.host, 'cheese');
+        assert.equal(message.facility, 'nonsense');
+        assert.equal(message._every1, 'Hello every one'); // the default value
+        assert.equal(message._every2, 'Overwritten!'); // the overwritten value
+        assert.equal(message._myField, 'This is my field!'); // the value for this message only
+        assert.equal(message.short_message, 'Just testing.'); // skip the field object 
+        assert.equal(message.full_message, 'Just testing.'); // should be as same as short_message 
+      }
+    }
   }
+
 }).export(module);


### PR DESCRIPTION
GELF supports additional fields (https://github.com/Graylog2/graylog2-docs/wiki/GELF), I added this support in 2 ways:
1. If user want to add custom fields for every message, add the key-value pairs to config.customFields

``` js
log4js.configure({
    appenders: [
        {
        type: "gelf",
        host: "LOG-SERVER",
        hostname: "nodejs-app",
        facility: "nodejs-facility",
        customFields: 
            {
                _http: 404,
                _application: "My Application",
            }   
        },
        {type: 'console'},
    ]
});
```
1. If users want to add/overwrite custom fields for some message, add it as the first object to the logger call:

``` js
logger({ GELF: true, _http:409, _application:"His Application" }, "This is an known issue")
```
