### PR TITLE
Browserify support

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,5 +38,8 @@
     "sandboxed-module": "0.1.3",
     "hook.io": "0.8.10",
     "underscore": "1.2.1"
+  },
+  "browser": {
+    "os": false
   }
 }


### PR DESCRIPTION
Browserify didn't find the `os` module. It's used only for getting the os's line endings (with a fallback), so this simply replaces the module with an empty object when compiled using browserify.
