### PR TITLE
GELF time precision should be millisecond level

### DIFF
--- a/lib/appenders/gelf.js
+++ b/lib/appenders/gelf.js
@@ -100,7 +100,7 @@ function gelfAppender (layout, host, port, hostname, facility) {
     msg.short_message = msg.full_message;
     
     msg.version="1.0";
-    msg.timestamp = msg.timestamp || new Date().getTime() / 1000 >> 0;
+    msg.timestamp = msg.timestamp || new Date().getTime() / 1000; // log should use millisecond 
     msg.host = hostname;
     msg.level = levelMapping[loggingEvent.level || levels.DEBUG];
     msg.facility = facility;


### PR DESCRIPTION
The GELF appender use second level precision for timestamp, changing it to millisecond should be more reasonable for production use.
