### PR TITLE
Export the function formatLogData() in module layout.js

### DIFF
--- a/lib/layouts.js
+++ b/lib/layouts.js
@@ -311,7 +311,8 @@ module.exports = {
   messagePassThroughLayout: messagePassThroughLayout, 
   patternLayout: patternLayout, 
   colouredLayout: colouredLayout, 
-  coloredLayout: colouredLayout, 
+  coloredLayout: colouredLayout,
+  formatLogData: formatLogData,
   layout: function(name, config) {
     return layoutMakers[name] && layoutMakers[name](config);
   }

--- a/test/layouts-test.js
+++ b/test/layouts-test.js
@@ -292,5 +292,17 @@ vows.describe('log4js layouts').addBatch({
       assert.ok(layouts.layout("coloured"));
       assert.ok(layouts.layout("pattern"));
     }
+  },
+
+  'formatLogData': {
+    topic: function() {
+      return require('../lib/layouts').formatLogData;
+    },
+    'should format the log data': function(formatLogData) {
+      assert.strictEqual(formatLogData('wayne'), 'wayne');
+      assert.strictEqual(formatLogData('It %s', 'works'), 'It works');
+      assert.strictEqual(formatLogData('Number %d', 10), 'Number 10');
+      assert.strictEqual(formatLogData('Object %j', {name: 'wayne'}), 'Object {"name":"wayne"}');
+    }
   }
 }).export(module);


### PR DESCRIPTION
We will create a custom appender that logs in the db. There we want to format the log message, but without any layout. So this pull request will help us to reuse your functionality instead of recreating the same logic in the appender.
