### PR TITLE
fix 'remote-addr' property in connect-logger

### DIFF
--- a/lib/connect-logger.js
+++ b/lib/connect-logger.js
@@ -120,10 +120,10 @@ function format(str, req, res) {
     .replace(':referrer', req.headers.referer || req.headers.referrer || '')
     .replace(':http-version', req.httpVersionMajor + '.' + req.httpVersionMinor)
     .replace(
-      ':remote-addr', 
+      ':remote-addr', req.ip || req._remoteAddress || ( 
       req.socket && 
         (req.socket.remoteAddress || (req.socket.socket && req.socket.socket.remoteAddress))
-    )
+    ))
     .replace(':user-agent', req.headers['user-agent'] || '')
     .replace(
       ':content-length', 


### PR DESCRIPTION
This patch fixes an issue with 'connect-logger' inserting the wrong `remote-addr` into all logs if an application is running behind a reverse-proxy. 

Connect will set the `req.ip` to the correct remote-addr, but as of now this property is not used at all in the log4js logging middleware.

What I did: adapt the `remote-addr` replacement to what connect is doing, https://github.com/senchalabs/connect/blob/master/lib/middleware/logger.js#L303.

There is no (new) test, because the existing ones work as they did before. `req.ip` and/or `req._remoteAddress` simply have precedence now when the client ip is requested. 
