### PR TITLE
Loggly appender should not make use of any layout

### DIFF
--- a/lib/appenders/loggly.js
+++ b/lib/appenders/loggly.js
@@ -1,6 +1,6 @@
-"use strict";
-var layouts = require("../layouts")
-, loggly = require("loggly")
+'use strict';
+var layouts = require('../layouts')
+, loggly = require('loggly')
 , os = require('os');
 
 /**
@@ -12,15 +12,62 @@ var layouts = require("../layouts")
  *   subdomain: 'your-subdomain',
  *   tags: ['loggly-tag1', 'loggly-tag2', .., 'loggly-tagn'] 
  * }
- * @param layout a function that takes a logevent and returns a string (defaults to basicLayout).
+ * @param layout a function that takes a logevent and returns a string (defaults to objectLayout).
  */
 function logglyAppender(config, layout) {
-	layout = layout || layouts.basicLayout;
-
 	var client = loggly.createClient(config);
+
+	var packageMessage = function (loggingEvent) {
+		var BaseItem = function(level, msg) {
+			this.level    = level || loggingEvent.level.toString();
+			this.category = loggingEvent.categoryName;
+			this.hostname = os.hostname().toString();
+			if (typeof msg !== 'undefined')
+				this.msg = msg;
+		};
+
+		var packageItem = function (item) {
+			if (item instanceof Error)
+				return new BaseItem('ERROR', item.message);
+
+			if (['string', 'number', 'boolean'].indexOf(typeof item) > -1 )
+				return new BaseItem(undefined, item);
+
+			var obj = new BaseItem();
+			if (Array.isArray(item))
+				return item.unshift(obj); //add base object as first item
+
+			if (item && Object.prototype.toString.call(item) === '[object Object]') {
+				for (var key in item) {
+					if (item.hasOwnProperty(key)) {
+						obj[key] = item[key]; //don't do packageItem on nested items, because level, category and hostname are needed on top level items only.
+					}
+				}
+			}
+
+			return obj;
+		};
+
+		if (loggingEvent.data.length === 1) {
+			return packageItem(loggingEvent.data[0]);
+		}
+		//length >1
+		var msg = loggingEvent.data;
+        for (var i = 0, l = msg.length; i < l; i++) {
+        	msg[i] = packageItem(msg[i]);
+        }
+
+		return msg;
+	};
 	
 	return function(loggingEvent) {
-		client.log(layout(loggingEvent), config.tags);
+		var a = layout ? layout(loggingEvent) : packageMessage(loggingEvent);
+		//console.log('log now', a);
+		client.log(a, config.tags, function(err, result) {
+			if (err) {
+				throw err;
+			}
+		});
 	};
 }
 
@@ -32,6 +79,6 @@ function configure(config) {
 	return logglyAppender(config, layout);
 }
 
-exports.name      = "loggly";
+exports.name      = 'loggly';
 exports.appender  = logglyAppender;
 exports.configure = configure;


### PR DESCRIPTION
Stop making use of any layout by default, because they are intended to
format a line for human reading. Loggly indexes the values (of all
properties of objects) and makes them available for querying.
