### PR TITLE
SMTP appender: use patternLayout for email subject

### DIFF
--- a/lib/appenders/smtp.js
+++ b/lib/appenders/smtp.js
@@ -15,7 +15,7 @@ var layouts = require("../layouts")
 */
 function smtpAppender(config, layout) {
 	layout = layout || layouts.basicLayout;
-	var subjectLayout = layouts.messagePassThroughLayout;
+	var subjectLayout = layouts.patternLayout(config.subject || '', {});
 	var sendInterval = config.sendInterval*1000 || 0;
 	
 	var logEventBuffer = [];
@@ -33,7 +33,7 @@ function smtpAppender(config, layout) {
 
       var msg = {
         to: config.recipients,
-        subject: config.subject || subjectLayout(firstEvent),
+        subject: config.subject ? subjectLayout(firstEvent) : layouts.messagePassThroughLayout(firstEvent),
         text: body,
         headers: { "Hostname": os.hostname() }
       };


### PR DESCRIPTION
This pull request changes the handling of the SMTP 'subject' option to use patternLayout instead of messagePassThroughLayout.

This means you can specify an appender like:

``` javascript
appender: {
    type: 'smtp',
    recipients: 'errors@company.com',
    subject: '%p on %h: %m'
}
```

Which will produce email subjects like: "ERROR on DEV-BOX03: foo is not a valid widget"

Apart from enabling pattern specifiers (%m etc), it works exactly as before:
- if subject is not specified, the subject will contain the first log message
- if a literal subject string is specified (eg, 'ERROR! please investgate...') it will be used verbatim
