### PR TITLE
fix shutdown method: make sure to callback when write completed immediat...

### DIFF
--- a/lib/appenders/file.js
+++ b/lib/appenders/file.js
@@ -85,6 +85,8 @@ function shutdown(cb) {
       file.once('drain', function() {
         file.end(done);
       });
+    } else {
+      file.end(done);
     }
   }, cb);
 }  


### PR DESCRIPTION
...ely

According to the document:
http://nodejs.org/api/stream.html#stream_writable_write_chunk_encoding_callback

The "write" may return true, which is not considered in the shutdown method.

A simple program can reproduce the error:

> var logger = log4js.getLogger();
> logger.error("just a test");
> log4js.shutdown(function(){
>    // will never reach here, and the process just stuck
>    process.exit(0);
> });
