### PR TITLE
file won't get rolled if the process restarted daily

### DIFF
--- a/lib/streams/DateRollingFileStream.js
+++ b/lib/streams/DateRollingFileStream.js
@@ -17,7 +17,14 @@ function DateRollingFileStream(filename, pattern, options, now) {
   }
   this.pattern = pattern || '.yyyy-MM-dd';
   this.now = now || Date.now;
-  this.lastTimeWeWroteSomething = format.asString(this.pattern, new Date(this.now()));
+
+  if (fs.existsSync(filename)) {
+    var stat = fs.statSync(filename);
+    this.lastTimeWeWroteSomething = format.asString(this.pattern, stat.mtime);
+  } else {
+    this.lastTimeWeWroteSomething = format.asString(this.pattern, new Date(this.now()));
+  }
+
   this.baseFilename = filename;
   this.alwaysIncludePattern = false;
   


### PR DESCRIPTION
The dateFile appender works fine for server processes, I found the problem when I use it in a daily cron job.

this.lastTimeWeWroteSomething is inited with current time, so if we restart a process on a daily base, it will always return the same date string,
 => The log file will never get rolled and it will keep growing.

The fix is done by checking existing log file, if there is one then get lastTimeWeWroteSomething from the file stat.
