### PR TITLE
Fixed: file appenders don't work in Windows.

### DIFF
--- a/lib/appenders/file.js
+++ b/lib/appenders/file.js
@@ -46,7 +46,7 @@ function fileAppender (file, layout, logSize, numBackups) {
       stream = fs.createWriteStream(
         file, 
         { encoding: "utf8", 
-          mode: parseInt('0644', 8), 
+          mode: os.platform() === 'win32' ?  parseInt('0666', 8) : parseInt('0644', 8),
           flags: 'a' }
       );
     }


### PR DESCRIPTION
In Windows, file mode '0644' will create the file in read-only mode.
Also, the UV source code says that, for that reason, in Windows, file mode 0666 should always be used.
See: http://stackoverflow.com/questions/22401319/write-logs-in-file-using-log4js-in-node-js/
See: http://stackoverflow.com/questions/23329451/node-file-modes-on-windows
