### PR TITLE
Update for "write after end" uncaught error.

### DIFF
--- a/lib/streams/BaseRollingFileStream.js
+++ b/lib/streams/BaseRollingFileStream.js
@@ -48,7 +48,6 @@ BaseRollingFileStream.prototype._write = function(chunk, encoding, callback) {
   function writeTheChunk() {
     debug("writing the chunk to the underlying stream");
     that.currentSize += chunk.length;
-    console.log(that.theStream);
     try {
       that.theStream.write(chunk, encoding, callback);
     }


### PR DESCRIPTION
I've had some issues around logging with or without cluster when logging in excess of 1000+ messages a second.
