### PR TITLE
Update connect-logger.js to work correctly with express

### DIFF
--- a/lib/connect-logger.js
+++ b/lib/connect-logger.js
@@ -84,6 +84,12 @@ function getLogger(logger4js, options) {
 				res.end = end;
 				res.end(chunk, encoding);
 				res.responseTime = new Date() - start;
+				//status code response level handling
+				if(res.statusCode && options.level === 'auto'){
+					level = levels.INFO;
+					if(res.statusCode >= 300) level = levels.WARN;
+					if(res.statusCode >= 400) level = levels.ERROR;
+				}
 				if (thislogger.isLevelEnabled(level)) {
 					if (typeof fmt === 'function') {
 						var line = fmt(req, res, function(str){ return format(str, req, res); });


### PR DESCRIPTION
When used with express levels are wrong since send() does not call writeHead, but sets responseCode on response.
