### PR TITLE
#233: Adding pid replacer to log layout

### DIFF
--- a/lib/layouts.js
+++ b/lib/layouts.js
@@ -125,6 +125,7 @@ function messagePassThroughLayout (loggingEvent) {
  *  - %d date in various formats
  *  - %% %
  *  - %n newline
+ *  - %k pid
  *  - %x{<tokenname>} add dynamic tokens to your log. Tokens are specified in the tokens parameter
  * You can use %[ and %] to define a colored block.
  *
@@ -211,6 +212,10 @@ function patternLayout (pattern, tokens) {
     return '%';
   }
 
+  function pid() {
+    return process.pid;
+  }
+
   function userDefined(loggingEvent, specifier) {
     if (typeof(tokens[specifier]) !== 'undefined') {
       if (typeof(tokens[specifier]) === 'function') {
@@ -233,6 +238,7 @@ function patternLayout (pattern, tokens) {
     '[': startColour,
     ']': endColour,
     '%': percent,
+    'k': pid,
     'x': userDefined
   };
 


### PR DESCRIPTION
This is a change to implement the feature requested in issue #233 (adding ability to add a pid to the log format)
