### PR TITLE
data option to loggly appender

### DIFF
--- a/docs/loggly.md
+++ b/docs/loggly.md
@@ -8,6 +8,7 @@ Sends logging events to [Loggly](https://www.loggly.com), optionally adding tags
 * `token` - `string` - your really long input token
 * `subdomain` - `string` - your subdomain
 * `tags` - `Array<string>` (optional) - tags to include in every log message
+* `data` - `object` (optional) - initial object that will be sent to loggly (extra properties will be added to a copy of this object before sending)
 
 This appender will scan the msg from the logging event, and pull out any argument of the
 shape `{ tags: [] }` so that it's possible to add additional tags in a normal logging call. See the example below.
@@ -21,6 +22,7 @@ log4js.configure({
       type: 'loggly',
       token: 'somethinglong',
       subdomain: 'your.subdomain',
+      data: { pid: process.pid },
       tags: [ 'tag1' ]
     }
   },

--- a/lib/appenders/loggly.js
+++ b/lib/appenders/loggly.js
@@ -55,6 +55,8 @@ function logglyAppender(config, layout) {
   const client = loggly.createClient(config);
   let openRequests = 0;
   let shutdownCB;
+  let payload = config.data || {};
+  payload.hostname = payload.hostname || os.hostname().toString();
 
   debug('creating appender.');
 
@@ -70,13 +72,12 @@ function logglyAppender(config, layout) {
 
     openRequests += 1;
     debug('sending log event to loggly');
-    client.log(
-      {
-        msg: msg,
-        level: loggingEvent.level.levelStr,
-        category: loggingEvent.categoryName,
-        hostname: os.hostname().toString(),
-      },
+    let data = Object.assign({}, payload);
+    data.msg = msg;
+    data.level = loggingEvent.level.levelStr;
+    data.category = loggingEvent.categoryName;
+
+    client.log(data,
       additionalTags,
       (error) => {
         if (error) {

--- a/lib/appenders/loggly.js
+++ b/lib/appenders/loggly.js
@@ -55,7 +55,7 @@ function logglyAppender(config, layout) {
   const client = loggly.createClient(config);
   let openRequests = 0;
   let shutdownCB;
-  let payload = config.data || {};
+  const payload = config.data || {};
   payload.hostname = payload.hostname || os.hostname().toString();
 
   debug('creating appender.');
@@ -72,7 +72,7 @@ function logglyAppender(config, layout) {
 
     openRequests += 1;
     debug('sending log event to loggly');
-    let data = Object.assign({}, payload);
+    const data = Object.assign({}, payload);
     data.msg = msg;
     data.level = loggingEvent.level.levelStr;
     data.category = loggingEvent.categoryName;


### PR DESCRIPTION
I was missing an ability to add extra fields to 'json' object visible in loggly interface as illustrated below:
![image](https://user-images.githubusercontent.com/1985429/29416868-b83482da-8367-11e7-9996-334ef63d487f.png)

By using configuration below I could now add branch and task fields and see them in loggly:
````
loggly: {
  type: './lib/loggly-appender', // using custom one for now
  token: process.env.LOGGLY_TOKEN,
  subdomain: process.env.LOGGLY_SUBDOMAIN,
  tags: ['web'],
  data: { branch:'develop', task:'web' },
  json: true
}
````

There shouldn't be any breaking changes, so I hope you will consider merging this PR.

Would you consider using alternative loggly client in the future? For example the one that is buffered and not dispatched right away with each event.

