### PR TITLE
fix: Remove setLevel from Logger TypeScript definition

### DIFF
--- a/types/log4js.d.ts
+++ b/types/log4js.d.ts
@@ -415,8 +415,6 @@ export interface Configuration {
 }
 
 export interface Logger {
-	setLevel(level: string): void;
-	setLevel(level: Level): void;
 	new(dispatch: Function, name: string): Logger;
 
 	level: string;


### PR DESCRIPTION
Logger no longer has a `setLevel` method.