### PR TITLE
V2.3.10 file lineno support

### DIFF
--- a/lib/layouts.js
+++ b/lib/layouts.js
@@ -2,6 +2,8 @@
 
 const dateFormat = require('date-format');
 const os = require('os');
+const path = require('path');
+const stackTrace = require('stack-trace');
 const util = require('util');
 
 const eol = os.EOL || '\n';
@@ -92,7 +94,7 @@ function colorize(str, style) {
 function timestampLevelAndCategory(loggingEvent, colour, timezoneOffset) {
   return colorize(
     formatLogData(
-      '[%s] [%s] %s - '
+      (process.env.LOG4JS_USE_STACKTRACE ? '[%s] [%s] %s %s %s - ' : '[%s] [%s] %s - ')
       , dateFormat.asString(loggingEvent.startTime, timezoneOffset)
       , loggingEvent.level
       , loggingEvent.categoryName
@@ -146,6 +148,8 @@ function dummyLayout(loggingEvent) {
  *  - %r time in toLocaleTimeString format
  *  - %p log level
  *  - %c log category
+ *  - %f log file information
+ *  - %l log line file information
  *  - %h hostname
  *  - %m log data
  *  - %d date in constious formats
@@ -173,7 +177,7 @@ function dummyLayout(loggingEvent) {
  */
 function patternLayout(pattern, tokens, timezoneOffset) {
   const TTCC_CONVERSION_PATTERN = '%r %p %c - %m%n';
-  const regex = /%(-?[0-9]+)?(\.?[0-9]+)?([[\]cdhmnprzxXy%])(\{([^}]+)\})?|([^%]+)/;
+  const regex = /%(-?[0-9]+)?(\.?[0-9]+)?([[\]cdhmlfnprzxXy%])(\{([^}]+)\})?|([^%]+)/;
 
   pattern = pattern || TTCC_CONVERSION_PATTERN;
 
@@ -218,6 +222,14 @@ function patternLayout(pattern, tokens, timezoneOffset) {
 
   function endOfLine() {
     return eol;
+  }
+
+  function fileInfo(loggingEvent) {
+    return loggingEvent.fileinfo;
+  }
+
+  function lineInfo(loggingEvent) {
+    return loggingEvent.lineinfo;
   }
 
   function logLevel(loggingEvent) {
@@ -275,6 +287,8 @@ function patternLayout(pattern, tokens, timezoneOffset) {
     'd': formatAsDate,
     'h': hostname,
     'm': formatMessage,
+    'f': fileInfo,
+    'l': lineInfo,	  
     'n': endOfLine,
     'p': logLevel,
     'r': startTime,

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -2,7 +2,9 @@
 
 'use strict';
 
-const debug = require('debug')('log4js:logger');
+const debug      = require('debug')('log4js:logger'),
+      stackTrace = require('stack-trace'),
+      path       = require('path');
 
 let cluster;
 try {
@@ -22,14 +24,19 @@ class LoggingEvent {
    * @param {String} categoryName name of category
    * @param {Log4js.Level} level level of message
    * @param {Array} data objects to log
+   * @param {Log4js.Logger} context the associated logger
+   * @param {String} fileinfo path and file of caller
+   * @param {String} lineinfo line and column of caller
    * @author Seth Chisamore
    */
-  constructor(categoryName, level, data, context) {
+  constructor(categoryName, level, data, context, fileinfo, lineinfo) {
     this.startTime = new Date();
     this.categoryName = categoryName;
     this.data = data;
     this.level = level;
     this.context = Object.assign({}, context);
+    this.fileinfo = fileinfo;
+    this.lineinfo = lineinfo;
     this.pid = process.pid;
     if (cluster && cluster.isWorker) {
       this.cluster = {
@@ -54,6 +61,7 @@ module.exports = function (levels, getLevelForCategory, setLevelForCategory) {
    * @author Stephan Strittmatter
    */
   class Logger {
+
     constructor(dispatch, name) {
       if (typeof dispatch !== 'function') {
         throw new Error('No dispatch function provided.');
@@ -91,7 +99,17 @@ module.exports = function (levels, getLevelForCategory, setLevelForCategory) {
 
     _log(level, data) {
       debug(`sending log data (${level}) to appenders`);
-      const loggingEvent = new LoggingEvent(this.category, level, data, this.context);
+      const v8CallSiteObject = stackTrace.get();
+      const frame = v8CallSiteObject.length ? v8CallSiteObject[2] : undefined;
+      let filepath = "File path unavailable";
+      let lineno = "Line number unavailable";
+      if (frame && typeof frame.getFileName === "function") {
+        filepath = path.relative(process.cwd(), frame.getFileName());
+      }
+      if (frame && typeof frame.getLineNumber === "function") {
+        lineno = frame.getLineNumber() + ":" + frame.getColumnNumber();
+      }
+      const loggingEvent = new LoggingEvent(this.category, level, data, this.context, filepath, lineno);
       this.dispatch(loggingEvent);
     }
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "date-format": "^1.1.0",
     "debug": "^2.6.8",
     "semver": "^5.3.0",
+    "stack-trace": "0.0.10",
     "streamroller": "^0.6.0"
   },
   "devDependencies": {

--- a/test/tap/consoleAppender-stacktrace-test.js
+++ b/test/tap/consoleAppender-stacktrace-test.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const test = require('tap').test;
+const sandbox = require('sandboxed-module');
+process.env.LOG4JS_USE_STACKTRACE = true;
+
+test('log4js console appender', (batch) => {
+  batch.test('should output to console', (t) => {
+    const messages = [];
+    const fakeConsole = {
+      log: function (msg) {
+        messages.push(msg);
+      }
+    };
+    const log4js = sandbox.require(
+      '../../lib/log4js',
+      {
+        globals: {
+          console: fakeConsole
+        }
+      }
+    );
+    log4js.configure({
+      appenders: { console: { type: 'console', layout: { type: 'pattern',  'pattern': '[%p] - %f : %l - %m' } } },
+      categories: { default: { appenders: ['console'], level: 'DEBUG' } }
+    });
+
+    log4js.getLogger().info('LOG4JS_USE_STACKTRACE:' + process.env.LOG4JS_USE_STACKTRACE);
+
+    t.equal(messages[0], '[INFO] - File path unavailable : Line number unavailable - LOG4JS_USE_STACKTRACE:true');
+    t.end();
+  });
+
+  batch.end();
+});


### PR DESCRIPTION
*For your consideration*: Pull request to support pattern layout with stack trace file information and file line number.

**Usage**

`process.env.LOG4JS_USE_STACKTRACE = true;`

```js
{
  "appenders": {
    "console-appender": {
      "type": "console",
      "layout": {
        "type": "pattern",
        "pattern": "%[[%p]%] - %18.100f : %7.12l - %[%m%]"
      }
    }
  },
  "categories": {
    "default": {
      "appenders": ["console-appender"],
      "level": "info"
    }
  }
}
```

**Sample**

See the following archive [log4js-stacktrace-sample.zip](https://github.com/log4js-node/log4js-node/files/1428006/log4js-stacktrace-sample.zip) for a real working sample.

**Tests**

New test `test/tap/consoleAppender-stacktrace-test.js`
FYI, something with the test running in the sandbox causes the stack track to be empty. All the other tests still pass. I didn't know enough about the `sandboxed-module` to understand why it effects the `stack-trace` module.

```shell
> tap 'test/tap/**/*.js'

test/tap/categoryFilter-test.js ....................... 6/6
test/tap/cluster-test.js ............................ 11/11
test/tap/configuration-test.js ........................ 4/4
test/tap/configuration-validation-test.js ........... 37/37
test/tap/connect-logger-test.js ..................... 32/32
test/tap/connect-nolog-test.js ...................... 33/33
test/tap/consoleAppender-stacktrace-test.js ........... 1/1
test/tap/consoleAppender-test.js ...................... 1/1
test/tap/dateFileAppender-test.js ..................... 8/8
test/tap/default-settings-test.js ..................... 3/3
test/tap/disable-cluster-test.js .....# Subtest: cluster master
....ok 1 - cluster master # time=5.903ms
1..1
test/tap/disable-cluster-test.js ...................... 9/9
test/tap/file-sighup-test.js .......................... 2/2
test/tap/fileAppender-test.js ....................... 21/21
test/tap/fileSyncAppender-test.js ................... 12/12
test/tap/gelfAppender-test.js ....................... 32/32
test/tap/hipchatAppender-test.js .................... 11/11
test/tap/layouts-test.js ............................ 87/87
test/tap/levels-test.js ........................... 259/259
test/tap/logFaces-HTTP-test.js ...................... 13/13
test/tap/logFaces-UDP-test.js ......................... 9/9
test/tap/logger-test.js ............................. 30/30
test/tap/logging-test.js ............................ 19/19
test/tap/logglyAppender-test.js ....................... 7/7
test/tap/logLevelFilter-test.js ....................... 6/6
test/tap/logstashUDP-test.js ........................ 22/22
test/tap/mailgunAppender-test.js .................... 23/23
test/tap/multi-file-appender-test.js ................ 11/11
test/tap/multiprocess-shutdown-test.js ................ 6/6 2s
test/tap/multiprocess-test.js ....................... 46/46
test/tap/newLevel-test.js ........................... 36/36
test/tap/pm2-support-test.js .......................... 6/6 2s
test/tap/redisAppender-test.js ...................... 15/15
test/tap/setLevel-asymmetry-test.js ................. 72/72
test/tap/slackAppender-test.js ...................... 20/20
test/tap/smtpAppender-test.js ....................... 55/55
test/tap/stacktraces-test.js .......................... 1/1
test/tap/stderrAppender-test.js ....................... 4/4
test/tap/stdoutAppender-test.js ....................... 2/2
test/tap/subcategories-test.js ...................... 19/19
total ............................................. 991/991

  991 passing (25s)

  ok
```