### PR TITLE
When a file stream is full, pause output.

### DIFF
--- a/lib/appenders/file.js
+++ b/lib/appenders/file.js
@@ -36,6 +36,7 @@ function fileAppender (file, layout, logSize, numBackups, compress, timezoneOffs
   //there has to be at least one backup if logSize has been specified
   numBackups = numBackups === 0 ? 1 : numBackups;
 
+  var paused = false;
   function openTheStream(file, fileSize, numFiles) {
     var stream;
     if (fileSize) {
@@ -56,6 +57,9 @@ function fileAppender (file, layout, logSize, numBackups, compress, timezoneOffs
     stream.on("error", function (err) {
       console.error("log4js.fileAppender - Writing to file %s, error happened ", file, err);
     });
+    stream.on("drain", function () {
+      that.paused = false;
+    });
     return stream;
   }
 
@@ -65,7 +69,12 @@ function fileAppender (file, layout, logSize, numBackups, compress, timezoneOffs
   openFiles.push(logFile);
 
   return function(loggingEvent) {
-    logFile.write(layout(loggingEvent, timezoneOffset) + eol, "utf8");
+    if (paused) {
+      return;
+    } else if (!logFile.write(layout(loggingEvent, timezoneOffset) + eol, "utf8")) {
+      process.stdout.write('write buffer full (possibly due to errors), dropping logs until it recovers.\n');
+      paused = true;
+    }
   };
 
 }


### PR DESCRIPTION
WritableStream.write returns false when the stream's buffer reaches its high
water mark.
(https://nodejs.org/api/stream.html#stream_writable_write_chunk_encoding_callback).
You can keep writing after that point, but data will just accumulate in a
buffer, producing a memory leak.

This can happen in particular when there is an error writing to a file, for
instance because the filesystem is full. Rather than leaking memory until the
process crashes, it is better to pause writes and lose some logs.

Fixes #620.