### PR TITLE
fix(cluster): added circular json dep

### DIFF
--- a/lib/appenders/multiprocess.js
+++ b/lib/appenders/multiprocess.js
@@ -2,6 +2,7 @@
 
 const debug = require('debug')('log4js:multiprocess');
 const net = require('net');
+const CircularJSON = require('circular-json');
 
 const END_MSG = '__LOG4JS__';
 
@@ -19,7 +20,7 @@ function logServer(config, actualAppender, levels) {
     debug('deserialising log event');
     let loggingEvent;
     try {
-      loggingEvent = JSON.parse(msg);
+      loggingEvent = CircularJSON.parse(msg);
       loggingEvent.startTime = new Date(loggingEvent.startTime);
       loggingEvent.level = levels.getLevel(loggingEvent.level.levelStr);
     } catch (e) {
@@ -98,13 +99,13 @@ function workerAppender(config) {
     // The following allows us to serialize errors correctly.
     // Validate that we really are in this case
     const logData = loggingEvent.data.map((e) => {
-      if (e && e.stack && JSON.stringify(e) === '{}') {
+      if (e && e.stack && CircularJSON.stringify(e) === '{}') {
         e = { stack: e.stack };
       }
       return e;
     });
     loggingEvent.data = logData;
-    socket.write(JSON.stringify(loggingEvent), 'utf8');
+    socket.write(CircularJSON.stringify(loggingEvent), 'utf8');
     socket.write(END_MSG, 'utf8');
   }
 

--- a/lib/log4js.js
+++ b/lib/log4js.js
@@ -24,6 +24,7 @@
  */
 const debug = require('debug')('log4js:main');
 const fs = require('fs');
+const CircularJSON = require('circular-json');
 const Configuration = require('./configuration');
 const connectModule = require('./connect-logger');
 const logger = require('./logger');
@@ -92,13 +93,13 @@ function serialise(logEvent) {
   // Validate that we really are in this case
   try {
     const logData = logEvent.data.map((e) => {
-      if (e && e.stack && JSON.stringify(e) === '{}') {
+      if (e && e.stack && CircularJSON.stringify(e) === '{}') {
         e = { message: e.message, stack: e.stack };
       }
       return e;
     });
     logEvent.data = logData;
-    return JSON.stringify(logEvent);
+    return CircularJSON.stringify(logEvent);
   } catch (e) {
     return serialise(new LoggingEvent(
       'log4js',
@@ -111,7 +112,7 @@ function serialise(logEvent) {
 function deserialise(serialised) {
   let event;
   try {
-    event = JSON.parse(serialised);
+    event = CircularJSON.parse(serialised);
     event.startTime = new Date(event.startTime);
     event.level = config.levels.getLevel(event.level.levelStr);
     event.data = event.data.map((e) => {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "lib": "lib"
   },
   "dependencies": {
+    "circular-json": "^0.4.0",
     "date-format": "^1.2.0",
     "debug": "^3.1.0",
     "semver": "^5.3.0",

--- a/test/tap/cluster-test.js
+++ b/test/tap/cluster-test.js
@@ -42,6 +42,8 @@ if (cluster.isMaster) {
         t.equal(logEvents[1].pid, workerPid);
         t.type(logEvents[1].data[1], 'Error');
         t.contains(logEvents[1].data[1].stack, 'Error: oh dear');
+        t.type(logEvents[1].data[2], 'object');
+        t.type(logEvents[1].data[2].me, 'object');
         t.equal(logEvents[2].categoryName, 'log4js');
         t.equal(logEvents[2].level.toString(), 'ERROR');
         t.equal(logEvents[2].data[0], 'Unable to parse log:');
@@ -61,7 +63,9 @@ if (cluster.isMaster) {
   });
 } else {
   const workerLogger = log4js.getLogger('worker');
-  workerLogger.info('this is worker', new Error('oh dear'));
+  const circle = {};
+  circle.me = circle;
+  workerLogger.info('this is worker', new Error('oh dear'), circle);
   // can't run the test in the worker, things get weird
   process.send({
     type: '::testing',


### PR DESCRIPTION
This is a fix for #523 - uses circular-json to handle circular references. As circular-json has a custom format for JSON, I haven't included these changes in the GELF, logFaces or logstash appenders as the things listening on the other end won't know what to do with it.