### PR TITLE
Use the "files" property to only include the `lib` folder when `npm install`ing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,11 @@
 {
   "name": "log4js",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "Port of Log4js to work with node.",
   "homepage": "https://log4js-node.github.io/log4js-node/",
+  "files": [
+    "lib"
+  ],
   "keywords": [
     "logging",
     "log",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "log4js",
-  "version": "2.4.2",
+  "version": "2.4.1",
   "description": "Port of Log4js to work with node.",
   "homepage": "https://log4js-node.github.io/log4js-node/",
   "files": [


### PR DESCRIPTION
Currently, `log4js-node` installs the entire project when being `npm install`ed. This is an anti-pattern, and it leads to a package almost 1MB larger than it needs to be, as it includes the entire set of docs every time it gets installed (among other things.)

This PR reduces the size of the `npm install`ed packaged to ~100KB by only including the bits that are `log4js`. This makes the project easier to used in constrained environments.

More details: https://docs.npmjs.com/files/package.json#files
