### PR TITLE
fix: deferred logger configuration.

### DIFF
--- a/lib/log4js.js
+++ b/lib/log4js.js
@@ -163,6 +163,10 @@ function isMaster() {
  * @return {Logger} instance of logger for the category
  */
 function getLogger(category) {
+  if (!enabled) {
+    configure(process.env.LOG4JS_CONFIG || defaultConfig);
+  }
+
   const cat = category || 'default';
   debug(`creating logger as ${isMaster() ? 'master' : 'worker'}`);
   return new Logger((isMaster() ? sendLogEventToAppender : workerDispatch), cat);
@@ -285,5 +289,3 @@ const log4js = {
 };
 
 module.exports = log4js;
-// set ourselves up
-configure(process.env.LOG4JS_CONFIG || defaultConfig);

--- a/test/tap/configuration-test.js
+++ b/test/tap/configuration-test.js
@@ -37,7 +37,7 @@ test('log4js configure', (batch) => {
       }
     };
 
-    sandbox.require(
+    const log4js = sandbox.require(
       '../../lib/log4js',
       {
         requires: {
@@ -45,6 +45,8 @@ test('log4js configure', (batch) => {
         }
       }
     );
+
+    log4js.getLogger('test-logger');
 
     delete process.env.LOG4JS_CONFIG;
 


### PR DESCRIPTION
logger will be configured either by user or at first call to getLogger.

According to documentation `If you do not call configure, log4js will use LOG4JS_CONFIG (if defined) or the default config.`
That is currently not the case as configure is called at module load time no matter if/when client code calls the configure.
This PR aims to fix this behavior.

Reasoning: we are using webpack for server packing and due to dynamic loading of appenders, these are not included in the final package (the suggestions in several bug reports don't work either).
In our project I would like to override the loading behavior to address the issue, but call to configure with the default config already tries to load the stdout which is not in the bundle and fails.

This PR preserves the original behavior without breaking backwards compatibility, but allows the client code to perform the configuration only once.