### PR TITLE
fix(#652): access levels before configure is called

### DIFF
--- a/lib/log4js.js
+++ b/lib/log4js.js
@@ -29,6 +29,7 @@ const Configuration = require('./configuration');
 const connectModule = require('./connect-logger');
 const logger = require('./logger');
 const layouts = require('./layouts');
+const levels = require('./levels');
 
 let cluster;
 try {
@@ -49,7 +50,6 @@ const defaultConfig = {
 let Logger;
 let LoggingEvent;
 let config;
-let connectLogger;
 let enabled = false;
 
 function configForCategory(category) {
@@ -284,7 +284,8 @@ const log4js = {
   getLogger,
   configure,
   shutdown,
-  connectLogger,
+  connectLogger: connectModule(levels()).connectLogger,
+  levels: levels(),
   addLayout: layouts.addLayout
 };
 

--- a/test/tap/levels-before-configure-test.js
+++ b/test/tap/levels-before-configure-test.js
@@ -1,0 +1,12 @@
+const test = require('tap').test;
+
+test('Accessing things setup in configure before configure is called', (batch) => {
+  batch.test('should work', (t) => {
+    const log4js = require('../../lib/log4js');
+    t.ok(log4js.levels);
+    t.ok(log4js.connectLogger);
+    t.end();
+  });
+
+  batch.end();
+});


### PR DESCRIPTION
This fixes the problem of trying to use levels before configure has been called (either explicitly or by the first call to `getLogger`). This was a change introduced by #648. The only problem with this fix is that the references to levels and connectLogger will be invalid after configure is called - but they will only be functionally different if there have been custom levels defined. And if you're defining custom levels in your config then you probably want to call configure before accessing levels anyway. 