### PR TITLE
feat(redis): quit on log4js.shutdown

### DIFF
--- a/lib/appenders/redis.js
+++ b/lib/appenders/redis.js
@@ -15,7 +15,7 @@ function redisAppender(config, layout) {
     }
   });
 
-  return function (loggingEvent) {
+  const appender = function (loggingEvent) {
     const message = layout(loggingEvent);
     redisClient.publish(config.channel, message, (err) => {
       if (err) {
@@ -23,6 +23,13 @@ function redisAppender(config, layout) {
       }
     });
   };
+
+  appender.shutdown = (cb) => {
+    redisClient.quit();
+    if (cb) cb();
+  };
+
+  return appender;
 }
 
 function configure(config, layouts) {

--- a/test/tap/redisAppender-test.js
+++ b/test/tap/redisAppender-test.js
@@ -19,7 +19,10 @@ function setupLogging(category, options) {
         publish: function (channel, message, callback) {
           fakeRedis.msgs.push({ channel: channel, message: message });
           fakeRedis.publishCb = callback;
-        }
+        },
+        quit: function () {
+          fakeRedis.quitCalled = true;
+        },
       };
     }
   };
@@ -46,6 +49,7 @@ function setupLogging(category, options) {
 
   return {
     logger: log4js.getLogger(category),
+    log4js: log4js,
     fakeRedis: fakeRedis,
     fakeConsole: fakeConsole
   };
@@ -127,6 +131,15 @@ test('log4js redisAppender', (batch) => {
       assert.end();
     });
     t.end();
+  });
+
+  batch.test('shutdown', (t) => {
+    const setup = setupLogging('shutdown', { type: 'redis', channel: 'testing' });
+
+    setup.log4js.shutdown(() => {
+      t.ok(setup.fakeRedis.quitCalled);
+      t.end();
+    });
   });
 
   batch.end();


### PR DESCRIPTION
This closes the `redisClient` connection upon `log4js.shutdown()`, allowing the process to exit cleanly.  Otherwise I found the redis connection prevents the process from exiting and effectively "hangs"

Let me know if you see any problems or would like me to make changes.

Thank you for an excellent project.

-Ben