### PR TITLE
Configure method for oneliners

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -10,6 +10,8 @@ If you are using `cluster`, then include the call to `configure` in the worker p
 
 Configuration objects must define at least one appender, and a default category. Log4js will throw an exception if the configuration is invalid.
 
+`configure` method call returns the configured log4js object.
+
 ### Configuration Object
 Properties:
 * `levels` (optional, object) - used for defining custom log levels, or redefining existing ones; this is a map with the level name as the key (string, case insensitive), and an object as the value. The object should have two properties: the level value (integer) as the value, and the colour. Log levels are used to assign importance to log messages, with the integer value being used to sort them. If you do not specify anything in your configuration, the default values are used (ALL < TRACE < DEBUG < INFO < WARN < ERROR < FATAL < MARK < OFF - note that OFF is intended to be used to turn off logging, not as a level for actual logging, i.e. you would never call `logger.off('some log message')`). Levels defined here are used in addition to the default levels, with the integer value being used to determine their relation to the default levels. If you define a level with the same name as a default level, then the integer value in the config takes precedence. Level names must begin with a letter, and can only contain letters, numbers and underscores.

--- a/lib/log4js.js
+++ b/lib/log4js.js
@@ -230,6 +230,8 @@ function configure(configurationFileOrObject) {
   }
 
   enabled = true;
+
+  return log4js;
 }
 
 /**

--- a/test/tap/configuration-test.js
+++ b/test/tap/configuration-test.js
@@ -3,54 +3,79 @@
 const test = require('tap').test;
 const sandbox = require('sandboxed-module');
 
-test('log4js configure', (batch) => {
-  batch.test('when configuration file loaded via LOG4JS_CONFIG env variable', (t) => {
-    process.env.LOG4JS_CONFIG = 'some/path/to/mylog4js.json';
-    let fileRead = 0;
-    const modulePath = 'some/path/to/mylog4js.json';
-    const pathsChecked = [];
-    const mtime = new Date();
+const modulePath = 'some/path/to/mylog4js.json';
+const pathsChecked = [];
 
-    const fakeFS = {
+let fakeFS = {};
+let dependencies;
+let fileRead;
+
+test('log4js configure', (batch) => {
+  batch.beforeEach((done) => {
+    fileRead = 0;
+
+    fakeFS = {
       config: {
         appenders: {
-          console: { type: 'console', layout: { type: 'messagePassThrough' } }
+          console: {
+            type: 'console',
+            layout: { type: 'messagePassThrough' }
+          }
         },
-        categories: { default: { appenders: ['console'], level: 'INFO' } }
+        categories: {
+          default: {
+            appenders: ['console'],
+            level: 'INFO'
+          }
+        }
       },
-      readdirSync: function (dir) {
-        return require('fs').readdirSync(dir);
-      },
-      readFileSync: function (file, encoding) {
+      readdirSync: dir => require('fs').readdirSync(dir),
+      readFileSync: (file, encoding) => {
         fileRead += 1;
-        t.type(file, 'string');
-        t.equal(file, modulePath);
-        t.equal(encoding, 'utf8');
+        batch.type(file, 'string');
+        batch.equal(file, modulePath);
+        batch.equal(encoding, 'utf8');
         return JSON.stringify(fakeFS.config);
       },
-      statSync: function (path) {
+      statSync: (path) => {
         pathsChecked.push(path);
         if (path === modulePath) {
-          return { mtime: mtime };
+          return { mtime: new Date() };
         }
         throw new Error('no such file');
       }
     };
 
-    const log4js = sandbox.require(
-      '../../lib/log4js',
-      {
-        requires: {
-          fs: fakeFS,
-        }
+    dependencies = {
+      requires: {
+        fs: fakeFS
       }
-    );
+    };
+
+    done();
+  });
+
+  batch.test('when configuration file loaded via LOG4JS_CONFIG env variable', (t) => {
+    process.env.LOG4JS_CONFIG = 'some/path/to/mylog4js.json';
+
+    const log4js = sandbox.require('../../lib/log4js', dependencies);
 
     log4js.getLogger('test-logger');
+    t.equal(fileRead, 1, 'should load the specified local config file');
 
     delete process.env.LOG4JS_CONFIG;
 
-    t.equal(fileRead, 1, 'should load the specified local config file');
+    t.end();
+  });
+
+  batch.test('when configuration is set via configure() method call, return the log4js object', (t) => {
+    const log4js = sandbox.require('../../lib/log4js', dependencies).configure(fakeFS.config);
+    t.type(log4js, 'object', 'Configure method call should return the log4js object!');
+
+    const log = log4js.getLogger('daemon');
+    t.type(log, 'object', 'log4js object, returned by configure(...) method should be able to create log object.');
+    t.type(log.info, 'function');
+
     t.end();
   });
 

--- a/types/log4js.d.ts
+++ b/types/log4js.d.ts
@@ -1,9 +1,18 @@
 // Type definitions for log4js
 
+export interface Log4js {
+	getLogger,
+	configure,
+	addLayout,
+	connectLogger,
+	levels,
+	shutdown
+}
+
 export function getLogger(category?: string): Logger;
 
-export function configure(filename: string): void;
-export function configure(config: Configuration): void;
+export function configure(filename: string): Log4js;
+export function configure(config: Configuration): Log4js;
 
 export function addLayout(name: string, config: (a: any) => (logEvent: LoggingEvent) => string): void;
 

--- a/types/test.ts
+++ b/types/test.ts
@@ -108,3 +108,8 @@ configure({
 	appenders: { cheese: { type: 'file', filename: 'cheese.log' } },
 	categories: { default: { appenders: ['cheese'], level: 'error' } }
 });
+
+log4js.configure('./filename').getLogger();
+const logger7 = log4js.getLogger();
+logger7.level = 'debug';
+logger7.debug("Some debug messages");


### PR DESCRIPTION
The changes within this PR allow to write code like:
```javascript
const log = require('log4js').configure(conf).getLogger('daemon');
```

For this PR I have:

1. Added `return` statement for log4js.configure(...) method.
2. Refactored the `configuration-test.js` file.
3. Added new test to `configuration-test.js` file. This test checks  the value, returned by `log4js.configure(...)` method.
4. Appended the `configure(...)` related article in the docs.