### PR TITLE
feat: Enable maxLogSize with unit

### DIFF
--- a/lib/appender-adapter.js
+++ b/lib/appender-adapter.js
@@ -1,0 +1,49 @@
+function maxFileSizeUnitTransform(maxLogSize) {
+  if (typeof maxLogSize === 'number' && Number.isInteger(maxLogSize)) {
+    return maxLogSize;
+  }
+
+  const units = {
+    K: 1024,
+    M: 1024 * 1024,
+    G: 1024 * 1024 * 1024,
+  };
+  const validUnit = Object.keys(units);
+  const unit = maxLogSize.substr(maxLogSize.length - 1).toLocaleUpperCase();
+  const value = maxLogSize.substring(0, maxLogSize.length - 1).trim();
+
+  if (validUnit.indexOf(unit) < 0 || !Number.isInteger(Number(value))) {
+    throw Error(`maxLogSize: "${maxLogSize}" is invalid`);
+  } else {
+    return value * units[unit];
+  }
+}
+
+function adapter(configAdapter, config) {
+  Object.keys(configAdapter).forEach((key) => {
+    if (config[key]) {
+      config[key] = configAdapter[key](config[key]);
+    }
+  });
+}
+
+function fileAppenderAdapter(config) {
+  const configAdapter = {
+    maxLogSize: maxFileSizeUnitTransform
+  };
+  adapter(configAdapter, config);
+}
+
+function fileSyncAppenderAdapter(config) {
+  const configAdapter = {
+    maxLogSize: maxFileSizeUnitTransform
+  };
+  adapter(configAdapter, config);
+}
+
+const appenderAdapter = {
+  file: fileAppenderAdapter,
+  fileSync: fileSyncAppenderAdapter
+};
+
+module.exports = appenderAdapter;

--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -4,6 +4,7 @@ const util = require('util');
 const path = require('path');
 const levels = require('./levels');
 const layouts = require('./layouts');
+const appenderAdapter = require('./appender-adapter');
 const debug = require('debug')('log4js:configuration');
 
 let cluster;
@@ -69,6 +70,11 @@ class Configuration {
 
   createAppender(name, config) {
     const appenderModule = this.loadAppenderModule(config.type);
+
+    if (appenderAdapter[config.type]) {
+      appenderAdapter[config.type](config);
+    }
+
     this.throwExceptionIf(
       not(appenderModule),
       `appender "${name}" is not valid (type "${config.type}" could not be found)`

--- a/types/log4js.d.ts
+++ b/types/log4js.d.ts
@@ -106,7 +106,7 @@ export interface FileAppender {
 	// the path of the file where you want your logs written.
 	filename: string;
 	// the maximum size (in bytes) for the log file. If not specified, then no log rolling will happen.
-	maxLogSize?: number;
+	maxLogSize?: number | string;
 	// (default value = 5) - the number of old log files to keep during log rolling.
 	backups?: number;
 	// defaults to basic layout
@@ -125,7 +125,7 @@ export interface SyncfileAppender {
 	// the path of the file where you want your logs written.
 	filename: string;
 	// the maximum size (in bytes) for the log file. If not specified, then no log rolling will happen.
-	maxLogSize?: number;
+	maxLogSize?: number | string;
 	// (default value = 5) - the number of old log files to keep during log rolling.
 	backups?: number;
 	// defaults to basic layout


### PR DESCRIPTION
enable maxLogSize with unit: '1K', '1M', '1G'. like 
```
appenders: {
    app: { type: 'file', filename: 'logs/app.log', maxLogSize: '100K', backups: 3 }
}
```
supports the feature in #352 

add tests in fileAppender-test.js and fileSyncAppender-test.js