### PR TITLE
fix(#709): strict Log4js typings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8570,6 +8570,12 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
+    "typescript": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.8.3.tgz",
+      "integrity": "sha512-K7g15Bb6Ra4lKf7Iq2l/I5/En+hLIHmxWZGq3D4DIRNFxMNV6j2SHSvDOqs2tGd4UvD/fJvrwopzQXjLrT7Itw==",
+      "dev": true
+    },
     "uglify-js": {
       "version": "2.8.29",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",

--- a/package.json
+++ b/package.json
@@ -29,11 +29,12 @@
   },
   "scripts": {
     "clean": "find test -type f ! -name '*.json' ! -name '*.js' ! -name '.eslintrc' -delete && rm *.log",
-    "prepush": "npm test",
+    "prepush": "npm test && npm run typings",
     "commitmsg": "validate-commit-msg",
     "posttest": "npm run clean",
     "pretest": "eslint 'lib/**/*.js' 'test/**/*.js'",
     "test": "tap 'test/tap/**/*.js'",
+    "typings": "tsc -p types/tsconfig.json",
     "coverage": "tap 'test/tap/**/*.js' --cov",
     "codecov": "tap 'test/tap/**/*.js' --cov --coverage-report=lcov && codecov"
   },
@@ -59,6 +60,7 @@
     "nyc": "^11.7.3",
     "sandboxed-module": "^2.0.3",
     "tap": "^11.1.5",
+    "typescript": "^2.8.3",
     "validate-commit-msg": "^2.14.0"
   },
   "optionalDependencies": {

--- a/types/log4js.d.ts
+++ b/types/log4js.d.ts
@@ -1,12 +1,13 @@
 // Type definitions for log4js
 
 export interface Log4js {
-	getLogger,
-	configure,
-	addLayout,
-	connectLogger,
-	levels,
-	shutdown
+	getLogger(category?: string): Logger;
+	configure(filename: string): Log4js;
+	configure(config: Configuration): Log4js;
+	addLayout(name: string, config: (a: any) => (logEvent: LoggingEvent) => string): void;
+	connectLogger(logger: Logger, options: { format?: string; level?: string; nolog?: any; }): any;	// express.Handler;
+	levels(): Levels;
+	shutdown(cb?: (error: Error) => void): void | null;
 }
 
 export function getLogger(category?: string): Logger;
@@ -113,8 +114,8 @@ export interface FileAppender {
 	layout?: Layout;
 	numBackups?: number;
 	compress?: boolean; // compress the backups
-  // keep the file extension when rotating logs
-  keepFileExt?: boolean;
+	// keep the file extension when rotating logs
+	keepFileExt?: boolean;
 	encoding?: string;
 	mode?: number;
 	flags?: string;
@@ -161,8 +162,8 @@ export interface DateFileAppender {
 	compress?: boolean;
 	// include the pattern in the name of the current log file as well as the backups.(default false)
 	alwaysIncludePattern?: boolean;
-  // keep the file extension when rotating logs
-  keepFileExt?: boolean;
+	// keep the file extension when rotating logs
+	keepFileExt?: boolean;
 	// if this value is greater than zero, then files older than that many days will be deleted during log rolling.(default 0)
 	daysToKeep?: number;
 }
@@ -432,7 +433,7 @@ export interface Logger {
 
 	isLevelEnabled(level?: string): boolean;
 
-  isTraceEnabled(): boolean;
+	isTraceEnabled(): boolean;
 	isDebugEnabled(): boolean;
 	isInfoEnabled(): boolean;
 	isWarnEnabled(): boolean;

--- a/types/test.ts
+++ b/types/test.ts
@@ -52,6 +52,7 @@ log4js.configure({
 });
 
 const logger4 = log4js.getLogger('thing');
+logger4.log('logging a thing');
 
 const logger5 = log4js.getLogger('json-test');
 logger5.info('this is just a test');

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compileOnSave": false,
+  "compilerOptions": {
+    "strict": true,
+    "noUnusedParameters": true,
+    "noUnusedLocals": true,
+    "noEmit": true
+  }
+}


### PR DESCRIPTION
* Strictly type the exported Log4js interface.
* Test the typings for strictness using the TypesScript compiler.

The PR addresses #709.

A few things to note:

* I did not see a preferred version of npm to use when installing new dependencies. I use version `5.6.0` which makes some significant changes to the checked-in _package-lock.json_. If you'd prefer a different version of npm to tamp down those changes, I'd be happy to use it and squash the history.
* I added TypeScript as a dev dependency and an npm script to test the typings, but I did not prescribe how that script runs automatically. If you'd like to see that in prepush or elsewhere I can make that change.