### PR TITLE
fix(#713): handle unexpected hangups in multiprocess appender

### DIFF
--- a/lib/appenders/multiprocess.js
+++ b/lib/appenders/multiprocess.js
@@ -64,8 +64,21 @@ function logServer(config, actualAppender, levels) {
       }
     }
 
+    function handleError(error) {
+      const loggingEvent = {
+        startTime: new Date(),
+        categoryName: 'log4js',
+        level: levels.ERROR,
+        data: ['A worker log process hung up unexpectedly', error],
+        remoteAddress: clientSocket.remoteAddress,
+        remotePort: clientSocket.remotePort
+      };
+      actualAppender(loggingEvent);
+    }
+
     clientSocket.on('data', chunkReceived);
     clientSocket.on('end', chunkReceived);
+    clientSocket.on('error', handleError);
   });
 
   server.listen(config.loggerPort || 5000, config.loggerHost || 'localhost', function () {

--- a/test/tap/multiprocess-test.js
+++ b/test/tap/multiprocess-test.js
@@ -236,6 +236,14 @@ test('Multiprocess Appender', (batch) => {
       assert.end();
     });
 
+    t.test('should log the error on "error" event', (assert) => {
+      net.cbs.error(new Error('Expected error'));
+      const logEvents = recording.replay();
+      assert.plan(2);
+      assert.equal(logEvents.length, 1);
+      assert.equal('A worker log process hung up unexpectedly', logEvents[0].data[0]);
+    });
+
     t.test('when a client connects', (assert) => {
       const logString = `${JSON.stringify({
         level: { level: 10000, levelStr: 'DEBUG' },

--- a/test/tap/multiprocess-worker.js
+++ b/test/tap/multiprocess-worker.js
@@ -1,0 +1,11 @@
+if (process.argv.indexOf('start-multiprocess-worker') >= 0) {
+  const log4js = require('../../lib/log4js');
+  const port = parseInt(process.argv[process.argv.length - 1], 10);
+  log4js.configure({
+    appenders: {
+      multi: { type: 'multiprocess', mode: 'worker', loggerPort: port }
+    },
+    categories: { default: { appenders: ['multi'], level: 'debug' } }
+  });
+  log4js.getLogger('worker').info('Logging from worker');
+}


### PR DESCRIPTION
Handle the `'error'` event on client sockets of worker logger.

Fixes #713 