### PR TITLE
Making Logger def a class instead of interface.

### DIFF
--- a/types/log4js.d.ts
+++ b/types/log4js.d.ts
@@ -424,7 +424,7 @@ export interface Configuration {
 	disableClustering?: boolean;
 }
 
-export interface Logger {
+export class Logger {
 	new(dispatch: Function, name: string): Logger;
 
 	level: string;


### PR DESCRIPTION
Doing this allows for typescript and angular to use the class as a dependency injection object.