### PR TITLE
Fix duplicate log messages in TCP server (fixes #761)

### DIFF
--- a/lib/appenders/tcp-server.js
+++ b/lib/appenders/tcp-server.js
@@ -5,22 +5,6 @@ const LoggingEvent = require('../LoggingEvent');
 
 const DELIMITER = '__LOG4JS__';
 
-let dataSoFar = '';
-const send = (data) => {
-  if (data) {
-    dataSoFar += data;
-    if (dataSoFar.indexOf(DELIMITER)) {
-      const events = dataSoFar.split(DELIMITER);
-      if (!dataSoFar.endsWith(DELIMITER)) {
-        dataSoFar = events.pop();
-      }
-      events.filter(e => e.length).forEach((e) => {
-        clustering.send(LoggingEvent.deserialise(e));
-      });
-    }
-  }
-};
-
 exports.configure = (config) => {
   debug('configure called with ', config);
   // dummy shutdown if we're not master
@@ -28,6 +12,24 @@ exports.configure = (config) => {
 
   clustering.onlyOnMaster(() => {
     const server = net.createServer((socket) => {
+      let dataSoFar = '';
+      const send = (data) => {
+        if (data) {
+          dataSoFar += data;
+          if (dataSoFar.indexOf(DELIMITER)) {
+            const events = dataSoFar.split(DELIMITER);
+            if (!dataSoFar.endsWith(DELIMITER)) {
+              dataSoFar = events.pop();
+            } else {
+              dataSoFar = '';
+            }
+            events.filter(e => e.length).forEach((e) => {
+              clustering.send(LoggingEvent.deserialise(e));
+            });
+          }
+        }
+      };
+
       socket.setEncoding('utf8');
       socket.on('data', send);
       socket.on('end', send);


### PR DESCRIPTION
This also fixes a potential concurrency issue by storing received data per socket connection instead of globally.