### PR TITLE
fix(#772): removed serialisation, replaced with freezing

### DIFF
--- a/docs/writing-appenders.md
+++ b/docs/writing-appenders.md
@@ -17,7 +17,7 @@ If that fails, an error will be raised.
 ## Appender Modules
 
 An appender module should export a single function called `configure`. The function should accept the following arguments:
-* `config` - `object` - the appender's configuration object
+* `config` - `object` - the appender's configuration object, note that this will be immutable (Object.freeze)
 * `layouts` - `module` - gives access to the [layouts](layouts.md) module, which most appenders will need
   * `layout` - `function(type, config)` - this is the main function that appenders will use to find a layout
 * `findAppender` - `function(name)` - if your appender is a wrapper around another appender (like the [logLevelFilter](logLevelFilter.md) for example), this function can be used to find another appender by name

--- a/lib/appenders/dateFile.js
+++ b/lib/appenders/dateFile.js
@@ -23,7 +23,7 @@ function appender(
   const logFile = new streams.DateRollingFileStream(
     filename,
     pattern,
-    options
+    Object.assign({}, options) // streamroller needs a writable options object
   );
 
   const app = function (logEvent) {
@@ -44,10 +44,6 @@ function configure(config, layouts) {
 
   if (config.layout) {
     layout = layouts.layout(config.layout.type, config.layout);
-  }
-
-  if (!config.alwaysIncludePattern) {
-    config.alwaysIncludePattern = false;
   }
 
   return appender(

--- a/lib/appenders/multiFile.js
+++ b/lib/appenders/multiFile.js
@@ -37,8 +37,8 @@ module.exports.configure = (config, layouts) => {
       debug('existing file appender is ', file);
       if (!file) {
         debug('creating new file appender');
-        config.filename = path.join(config.base, fileKey + config.extension);
-        file = fileAppender.configure(config, layouts);
+        const filename = path.join(config.base, fileKey + config.extension);
+        file = fileAppender.configure({ filename, ...config }, layouts);
         files.set(fileKey, file);
         if (config.timeout) {
           debug('creating new timer');

--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const util = require('util');
+const deepFreeze = require('deep-freeze');
 const debug = require('debug')('log4js:configuration');
 
 const listeners = [];
@@ -31,6 +32,11 @@ const throwExceptionIf = (config, checks, message) => {
 const configure = (candidate) => {
   debug('New configuration to be validated: ', candidate);
   throwExceptionIf(candidate, not(anObject(candidate)), 'must be an object.');
+
+  // freeze the config, so that it cannot be modified
+  // node-config does this anyway, so we do it to make sure
+  // nothing breaks when using that module
+  deepFreeze(candidate);
 
   debug(`Calling configuration listeners (${listeners.length})`);
   listeners.forEach(listener => listener(candidate));

--- a/lib/log4js.js
+++ b/lib/log4js.js
@@ -22,7 +22,6 @@
  */
 const debug = require('debug')('log4js:main');
 const fs = require('fs');
-const CircularJSON = require('circular-json');
 const configuration = require('./configuration');
 const layouts = require('./layouts');
 const levels = require('./levels');
@@ -59,10 +58,7 @@ function configure(configurationFileOrObject) {
   }
   debug(`Configuration is ${configObject}`);
 
-  // Fix for #743 - clone the config to avoid that is not writable in appenders
-  // When the node-config module is used, config object becomes immutable.
-  const clonedConfigObject = CircularJSON.parse(CircularJSON.stringify(configObject));
-  configuration.configure(clonedConfigObject);
+  configuration.configure(configObject);
 
   clustering.onMessage(sendLogEventToAppender);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -779,6 +779,11 @@
         }
       }
     },
+    "deep-freeze": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/deep-freeze/-/deep-freeze-0.0.1.tgz",
+      "integrity": "sha1-OgsABd4YZygZ39OM0x+RF5yJPoQ="
+    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "circular-json": "^0.5.5",
     "date-format": "^1.2.0",
     "debug": "^3.1.0",
+    "deep-freeze": "0.0.1",
     "streamroller": "0.7.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Rather than use JSON serialising and deserialising to copy an immutable config object (if it comes from node-config), which causes problems for the pattern layout user-defined functions, I've made it so that the config passed to appenders is always immutable and they will have to deal with that. This only caused problems for the dateFile and multiFile appenders in the core. Optional appenders may have problems with it (GELF, logstashUDP, and smtp appenders will all need fixing). 

Because this is potentially a breaking change, I'll bump up the version number to 4.x. I won't push this out until I've updated the GELF, logstashUDP and SMTP appenders to work with it.