### PR TITLE
fix: #743 and pr #766 cause other issues

### DIFF
--- a/lib/log4js.js
+++ b/lib/log4js.js
@@ -22,7 +22,7 @@
  */
 const debug = require('debug')('log4js:main');
 const fs = require('fs');
-const CircularJSON = require('circular-json');
+const deepClone = require('rfdc')({ proto: true });
 const configuration = require('./configuration');
 const layouts = require('./layouts');
 const levels = require('./levels');
@@ -59,10 +59,7 @@ function configure(configurationFileOrObject) {
   }
   debug(`Configuration is ${configObject}`);
 
-  // Fix for #743 - clone the config to avoid that is not writable in appenders
-  // When the node-config module is used, config object becomes immutable.
-  const clonedConfigObject = CircularJSON.parse(CircularJSON.stringify(configObject));
-  configuration.configure(clonedConfigObject);
+  configuration.configure(deepClone(configObject));
 
   clustering.onMessage(sendLogEventToAppender);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -779,6 +779,12 @@
         }
       }
     },
+    "deep-freeze": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/deep-freeze/-/deep-freeze-0.0.1.tgz",
+      "integrity": "sha1-OgsABd4YZygZ39OM0x+RF5yJPoQ=",
+      "dev": true
+    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -5721,6 +5727,11 @@
         "onetime": "^2.0.0",
         "signal-exit": "^3.0.2"
       }
+    },
+    "rfdc": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.1.2.tgz",
+      "integrity": "sha512-92ktAgvZhBzYTIK0Mja9uen5q5J3NRVMoDkJL2VMwq6SXjVCgqvQeVP2XAaUY6HT+XpQYeLSjb3UoitBryKmdA=="
     },
     "right-align": {
       "version": "0.1.3",

--- a/package.json
+++ b/package.json
@@ -45,18 +45,20 @@
     "circular-json": "^0.5.5",
     "date-format": "^1.2.0",
     "debug": "^3.1.0",
+    "rfdc": "^1.1.2",
     "streamroller": "0.7.0"
   },
   "devDependencies": {
+    "@log4js-node/sandboxed-module": "^2.1.0",
     "codecov": "^3.0.2",
     "conventional-changelog": "^1.1.24",
+    "deep-freeze": "0.0.1",
     "eslint": "^4.19.1",
     "eslint-config-airbnb-base": "^12.1.0",
     "eslint-import-resolver-node": "^0.3.1",
     "eslint-plugin-import": "^2.11.0",
     "husky": "^0.14.3",
     "nyc": "^11.7.3",
-    "@log4js-node/sandboxed-module": "^2.1.0",
     "tap": "^11.1.5",
     "typescript": "^2.8.3",
     "validate-commit-msg": "^2.14.0"

--- a/test/tap/configuration-validation-test.js
+++ b/test/tap/configuration-validation-test.js
@@ -7,6 +7,7 @@ const sandbox = require('@log4js-node/sandboxed-module');
 const log4js = require('../../lib/log4js');
 const configuration = require('../../lib/configuration');
 const debug = require('debug')('log4js:test.configuration-validation');
+const deepFreeze = require('deep-freeze');
 
 const testAppender = (label, result) => ({
   configure: function (config, layouts, findAppender) {
@@ -342,6 +343,18 @@ test('log4js configuration validation', (batch) => {
       appenders: { thing: { type: 'stdout' } },
       categories: { default: { appenders: ['thing'], level: log4js.levels.ERROR } }
     }));
+    t.end();
+  });
+
+  batch.test('should not throw error if configure object is freezed', (t) => {
+    t.doesNotThrow(() => log4js.configure(deepFreeze({
+      appenders: {
+        dateFile: {
+          type: 'dateFile', filename: 'test/tap/freeze-date-file-test', alwaysIncludePattern: false
+        }
+      },
+      categories: { default: { appenders: ['dateFile'], level: log4js.levels.ERROR } }
+    })));
     t.end();
   });
 


### PR DESCRIPTION
pr #766 try to fix #743 use serialisation to copy input config.
but cause other issues (#774 #772 )
this pr uses `rfdc` deep-clone the input config return a new unfreeze config object.
temporary fix until 4.0 ?