### PR TITLE
fix require.main for use with Node.js mjs modules

### DIFF
--- a/lib/appenders/index.js
+++ b/lib/appenders/index.js
@@ -34,7 +34,7 @@ const tryLoading = (modulePath, config) => {
 const loadAppenderModule = (type, config) => coreAppenders.get(type) ||
   tryLoading(`./${type}`, config) ||
   tryLoading(type, config) ||
-  tryLoading(path.join(path.dirname(require.main.filename), type), config) ||
+  (require.main && tryLoading(path.join(path.dirname(require.main.filename), type), config)) ||
   tryLoading(path.join(process.cwd(), type), config);
 
 const createAppender = (name, config) => {


### PR DESCRIPTION
When using the experimental ES2015 support with Node.js (mjs modules) the main property of require is undefined causing the third check to fail to loading appenders to always fail. This simple fix will enable the fourth check to execute when loading mjs modules.