### PR TITLE
refactor(multiprocess): serialisation consistency

### DIFF
--- a/lib/appenders/multiprocess.js
+++ b/lib/appenders/multiprocess.js
@@ -2,7 +2,7 @@
 
 const debug = require('debug')('log4js:multiprocess');
 const net = require('net');
-const CircularJSON = require('circular-json');
+const LoggingEvent = require('../LoggingEvent');
 
 const END_MSG = '__LOG4JS__';
 
@@ -18,21 +18,7 @@ function logServer(config, actualAppender, levels) {
    */
   function deserializeLoggingEvent(clientSocket, msg) {
     debug('deserialising log event');
-    let loggingEvent;
-    try {
-      loggingEvent = CircularJSON.parse(msg);
-      loggingEvent.startTime = new Date(loggingEvent.startTime);
-      loggingEvent.level = levels.getLevel(loggingEvent.level.levelStr);
-    } catch (e) {
-      // JSON.parse failed, just log the contents probably a naughty.
-      loggingEvent = {
-        startTime: new Date(),
-        categoryName: 'log4js',
-        level: levels.ERROR,
-        data: ['Unable to parse log:', msg]
-      };
-    }
-
+    const loggingEvent = LoggingEvent.deserialise(msg);
     loggingEvent.remoteAddress = clientSocket.remoteAddress;
     loggingEvent.remotePort = clientSocket.remotePort;
 
@@ -108,17 +94,7 @@ function workerAppender(config) {
 
   function write(loggingEvent) {
     debug('Writing log event to socket');
-    // JSON.stringify(new Error('test')) returns {}, which is not really useful for us.
-    // The following allows us to serialize errors correctly.
-    // Validate that we really are in this case
-    const logData = loggingEvent.data.map((e) => {
-      if (e && e.stack && CircularJSON.stringify(e) === '{}') {
-        e = { stack: e.stack };
-      }
-      return e;
-    });
-    loggingEvent.data = logData;
-    socket.write(CircularJSON.stringify(loggingEvent), 'utf8');
+    socket.write(loggingEvent.serialise(), 'utf8');
     socket.write(END_MSG, 'utf8');
   }
 


### PR DESCRIPTION
Delegate all serialisation tasks to LoggingEvent, instead of
maintaining a separate codepath in the multiprocess appender