### PR TITLE
fix(#789): use flatted in place of CircularJSON

### DIFF
--- a/lib/LoggingEvent.js
+++ b/lib/LoggingEvent.js
@@ -1,4 +1,4 @@
-const CircularJSON = require('circular-json');
+const flatted = require('flatted');
 const levels = require('./levels');
 
 /**
@@ -33,13 +33,13 @@ class LoggingEvent {
       return e;
     });
     this.data = logData;
-    return CircularJSON.stringify(this);
+    return flatted.stringify(this);
   }
 
   static deserialise(serialised) {
     let event;
     try {
-      const rehydratedEvent = CircularJSON.parse(serialised);
+      const rehydratedEvent = flatted.parse(serialised);
       rehydratedEvent.data = rehydratedEvent.data.map((e) => {
         if (e && e.message && e.stack) {
           const fakeError = new Error(e);

--- a/package-lock.json
+++ b/package-lock.json
@@ -322,11 +322,6 @@
       "integrity": "sha512-SK/846h/Rcy8q9Z9CAwGBLfCJ6EkjJWdpelWDufQpqVDYq2Wnnv8zlSO6AMQap02jvhVruKKpEtQOufo3pFhLg==",
       "dev": true
     },
-    "circular-json": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.5.5.tgz",
-      "integrity": "sha512-13YaR6kiz0kBNmIVM87Io8Hp7bWOo4r61vkEANy8iH9R9bc6avud/1FT0SBpqR1RpIQADOh/Q+yHZDA1iL6ysA=="
-    },
     "clean-yaml-object": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/clean-yaml-object/-/clean-yaml-object-0.1.0.tgz",
@@ -1294,6 +1289,11 @@
           "dev": true
         }
       }
+    },
+    "flatted": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.0.tgz",
+      "integrity": "sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg=="
     },
     "foreground-child": {
       "version": "1.5.6",

--- a/package.json
+++ b/package.json
@@ -42,9 +42,9 @@
     "lib": "lib"
   },
   "dependencies": {
-    "circular-json": "^0.5.5",
     "date-format": "^1.2.0",
     "debug": "^3.1.0",
+    "flatted": "^2.0.0",
     "rfdc": "^1.1.2",
     "streamroller": "0.7.0"
   },

--- a/test/tap/LoggingEvent-test.js
+++ b/test/tap/LoggingEvent-test.js
@@ -1,13 +1,14 @@
+const flatted = require('flatted');
 const test = require('tap').test;
 const LoggingEvent = require('../../lib/LoggingEvent');
 const levels = require('../../lib/levels');
 
 test('LoggingEvent', (batch) => {
-  batch.test('should serialise to JSON', (t) => {
+  batch.test('should serialise to flatted', (t) => {
     const event = new LoggingEvent('cheese', levels.DEBUG, ['log message'], { user: 'bob' });
     // set the event date to a known value
     event.startTime = new Date(Date.UTC(2018, 1, 4, 18, 30, 23, 10));
-    const rehydratedEvent = JSON.parse(event.serialise());
+    const rehydratedEvent = flatted.parse(event.serialise());
     t.equal(rehydratedEvent.startTime, '2018-02-04T18:30:23.010Z');
     t.equal(rehydratedEvent.categoryName, 'cheese');
     t.equal(rehydratedEvent.level.levelStr, 'DEBUG');
@@ -17,16 +18,16 @@ test('LoggingEvent', (batch) => {
     t.end();
   });
 
-  batch.test('should deserialise from JSON', (t) => {
-    const dehydratedEvent = `{
-      "startTime": "2018-02-04T10:25:23.010Z",
-      "categoryName": "biscuits",
-      "level": {
-        "levelStr": "INFO"
+  batch.test('should deserialise from flatted', (t) => {
+    const dehydratedEvent = flatted.stringify({
+      startTime: '2018-02-04T10:25:23.010Z',
+      categoryName: 'biscuits',
+      level: {
+        levelStr: 'INFO'
       },
-      "data": [ "some log message", { "x": 1 } ],
-      "context": { "thing": "otherThing" }
-    }`;
+      data: ['some log message', { x: 1 }],
+      context: { thing: 'otherThing' }
+    });
     const event = LoggingEvent.deserialise(dehydratedEvent);
     t.type(event, LoggingEvent);
     t.same(event.startTime, new Date(Date.UTC(2018, 1, 4, 10, 25, 23, 10)));

--- a/test/tap/multiprocess-test.js
+++ b/test/tap/multiprocess-test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const test = require('tap').test;
+const flatted = require('flatted');
 const sandbox = require('@log4js-node/sandboxed-module');
 const recording = require('../../lib/appenders/recording');
 
@@ -94,23 +95,23 @@ test('Multiprocess Appender', (batch) => {
     });
 
     t.test('should buffer messages written before socket is connected', (assert) => {
-      assert.include(net.data[0], JSON.stringify('before connect'));
+      assert.include(net.data[0], 'before connect');
       assert.end();
     });
 
-    t.test('should write log messages to socket as json strings with a terminator string', (assert) => {
-      assert.include(net.data[0], JSON.stringify('before connect'));
+    t.test('should write log messages to socket as flatted strings with a terminator string', (assert) => {
+      assert.include(net.data[0], 'before connect');
       assert.equal(net.data[1], '__LOG4JS__');
-      assert.include(net.data[2], JSON.stringify('after connect'));
+      assert.include(net.data[2], 'after connect');
       assert.equal(net.data[3], '__LOG4JS__');
       assert.equal(net.encoding, 'utf8');
       assert.end();
     });
 
     t.test('should attempt to re-open the socket on error', (assert) => {
-      assert.include(net.data[4], JSON.stringify('after error, before connect'));
+      assert.include(net.data[4], 'after error, before connect');
       assert.equal(net.data[5], '__LOG4JS__');
-      assert.include(net.data[6], JSON.stringify('after error, after connect'));
+      assert.include(net.data[6], 'after error, after connect');
       assert.equal(net.data[7], '__LOG4JS__');
       assert.equal(net.createConnectionCalled, 2);
       assert.end();
@@ -118,10 +119,10 @@ test('Multiprocess Appender', (batch) => {
 
     t.test('should serialize an Error correctly', (assert) => {
       assert.ok(
-        JSON.parse(net.data[8]).data[0].stack,
+        flatted.parse(net.data[8]).data[0].stack,
         `Expected:\n\n${net.data[8]}\n\n to have a 'data[0].stack' property`
       );
-      const actual = JSON.parse(net.data[8]).data[0].stack;
+      const actual = flatted.parse(net.data[8]).data[0].stack;
       assert.match(actual, /^Error: Error test/);
       assert.end();
     });
@@ -160,11 +161,11 @@ test('Multiprocess Appender', (batch) => {
 
     t.test('should attempt to re-open the socket', (assert) => {
       // skipping the __LOG4JS__ separators
-      assert.include(net.data[0], JSON.stringify('before connect'));
-      assert.include(net.data[2], JSON.stringify('after connect'));
-      assert.include(net.data[4], JSON.stringify('after timeout, before close'));
-      assert.include(net.data[6], JSON.stringify('after close, before connect'));
-      assert.include(net.data[8], JSON.stringify('after close, after connect'));
+      assert.include(net.data[0], 'before connect');
+      assert.include(net.data[2], 'after connect');
+      assert.include(net.data[4], 'after timeout, before close');
+      assert.include(net.data[6], 'after close, before connect');
+      assert.include(net.data[8], 'after close, after connect');
       assert.equal(net.createConnectionCalled, 2);
       assert.end();
     });
@@ -245,19 +246,19 @@ test('Multiprocess Appender', (batch) => {
     });
 
     t.test('when a client connects', (assert) => {
-      const logString = `${JSON.stringify({
+      const logString = `${flatted.stringify({
         level: { level: 10000, levelStr: 'DEBUG' },
         data: ['some debug']
       })}__LOG4JS__`;
 
-      net.cbs.data(`${JSON.stringify({
+      net.cbs.data(`${flatted.stringify({
         level: { level: 40000, levelStr: 'ERROR' },
         data: ['an error message']
       })}__LOG4JS__`);
       net.cbs.data(logString.substring(0, 10));
       net.cbs.data(logString.substring(10));
       net.cbs.data(logString + logString + logString);
-      net.cbs.end(`${JSON.stringify({
+      net.cbs.end(`${flatted.stringify({
         level: { level: 50000, levelStr: 'FATAL' },
         data: ["that's all folks"]
       })}__LOG4JS__`);

--- a/test/tap/tcp-appender-test.js
+++ b/test/tap/tcp-appender-test.js
@@ -1,6 +1,7 @@
 const test = require('tap').test;
 const net = require('net');
 const log4js = require('../../lib/log4js');
+const LoggingEvent = require('../../lib/LoggingEvent');
 
 const messages = [];
 const server = net.createServer((socket) => {
@@ -9,7 +10,7 @@ const server = net.createServer((socket) => {
     data
       .split('__LOG4JS__')
       .filter(s => s.length)
-      .forEach((s) => { messages.push(JSON.parse(s)); });
+      .forEach((s) => { messages.push(LoggingEvent.deserialise(s)); });
   });
 });
 


### PR DESCRIPTION
CircularJSON is now deprecated, so replace it with its successor
and use it in the sole location where we used CircularJSON, ie
in the LoggingEvent serialization/deserialization functions

* npm - install flatted, remove circular-json
* LoggingEvent - use flatted for serialization/deserialization
* tests - acknowledge that flatted (and circular-json) should not
  parse anything other than their respective serialized payloads
  and use flatted when parsing/stringifying test data

Fixes #789 