### PR TITLE
[fix]change wrong property name, from 'numBackups' to 'backups'

### DIFF
--- a/examples/log-to-files.js
+++ b/examples/log-to-files.js
@@ -7,7 +7,7 @@ log4js.configure(
         type: 'file',
         filename: 'important-things.log',
         maxLogSize: 10 * 1024 * 1024, // = 10Mb
-        numBackups: 5, // keep five backup files
+        backups: 5, // keep five backup files
         compress: true, // compress the backups
         encoding: 'utf-8',
         mode: 0o0640,


### PR DESCRIPTION
Property name is wrong of example code.
I think that property name is backups, not numBackups when config.type is 'file'.

https://github.com/log4js-node/log4js-node/blob/86333dc57d86928c7f4617bd439724840d3ace2f/lib/appenders/file.js#L92

document
https://log4js-node.github.io/log4js-node/file.html

thx.