### PR TITLE
FeatureRequest: nolog in general config #640

### DIFF
--- a/docs/noLogFilter.md
+++ b/docs/noLogFilter.md
@@ -1,0 +1,58 @@
+# Category Filter
+
+The no log filter allows you to exclude the log events that an appender will record. 
+The log events will be excluded depending on the regular expressions provided in the configuration.
+This can be useful when you debug your application and you want to exclude some noisily logs that are irrelevant to your investigation. 
+You can stop to log them through a regular expression. 
+
+## Configuration
+
+* `type` - `"noLogFilter"`
+* `exclude` - `string | Array<string>` - the regular expression (or the regular expressions if you provide an array of values) will be used for evaluating the events to pass to the appender. The events, which will match the regular expression, will be excluded and so not logged. 
+* `appender` - `string` - the name of an appender, defined in the same configuration, that you want to filter.
+
+## Example
+
+```javascript
+log4js.configure({
+  appenders: {
+    everything: { type: 'file', filename: 'all-the-logs.log' },
+    filtered: { 
+      type: 'noLogFilter', 
+      exclude: 'not', 
+      appender: 'everything' }
+  },
+  categories: {
+    default: { appenders: [ 'filtered' ], level: 'debug' }
+  }
+});
+
+const logger = log4js.getLogger();
+logger.debug('I will be logged in all-the-logs.log');
+logger.debug('I will be not logged in all-the-logs.log');
+```
+
+Note that:
+* an array of strings can be specified in the configuration  
+* a case insensitive match will be done
+* empty strings will be not considered and so removed from the array of values
+
+```javascript
+log4js.configure({
+  appenders: {
+    everything: { type: 'file', filename: 'all-the-logs.log' },
+    filtered: { 
+      type: 'noLogFilter', 
+      exclude: ['NOT', '\\d', ''], 
+      appender: 'everything' }
+  },
+  categories: {
+    default: { appenders: [ 'filtered' ], level: 'debug' }
+  }
+});
+
+const logger = log4js.getLogger();
+logger.debug('I will be logged in all-the-logs.log');
+logger.debug('I will be not logged in all-the-logs.log');
+logger.debug('A 2nd message that will be excluded in all-the-logs.log');
+```

--- a/lib/appenders/noLogFilter.js
+++ b/lib/appenders/noLogFilter.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const debug = require('debug')('log4js:noLogFilter');
+
+/**
+ * The function removes empty or null regexp from the array
+ * @param {Array<string>} regexp
+ * @returns {Array<string>} a filtered string array with not empty or null regexp
+ */
+function removeNullOrEmptyRegexp(regexp) {
+  const filtered = regexp.filter(el => ((el != null) && (el !== '')));
+  return filtered;
+}
+
+/**
+ * Returns a function that will exclude the events in case they match
+ * with the regular expressions provided
+ * @param {string | Array<string>} filters contains the regexp that will be used for the evaluation
+ * @param {*} appender
+ * @returns {function}
+ */
+function noLogFilter(filters, appender) {
+  return (logEvent) => {
+    debug(`Checking data: ${logEvent.data} against filters: ${filters}`);
+    if (typeof filters === 'string') {
+      filters = [filters];
+    }
+    filters = removeNullOrEmptyRegexp(filters);
+    const regex = new RegExp(filters.join('|'), 'i');
+    if (filters.length === 0 ||
+      logEvent.data.findIndex(value => regex.test(value)) < 0) {
+      debug('Not excluded, sending to appender');
+      appender(logEvent);
+    }
+  };
+}
+
+function configure(config, layouts, findAppender) {
+  const appender = findAppender(config.appender);
+  return noLogFilter(config.exclude, appender);
+}
+
+module.exports.configure = configure;

--- a/test/tap/noLogFilter-test.js
+++ b/test/tap/noLogFilter-test.js
@@ -1,0 +1,177 @@
+'use strict';
+
+const test = require('tap').test;
+const log4js = require('../../lib/log4js');
+const recording = require('../../lib/appenders/recording');
+
+/**
+ * test a simple regexp
+ */
+test('log4js noLogFilter', (batch) => {
+  batch.beforeEach((done) => { recording.reset(); done(); });
+
+  batch.test('appender should exclude events that match the regexp string', (t) => {
+    log4js.configure({
+      appenders: {
+        recorder: { type: 'recording' },
+        filtered: {
+          type: 'noLogFilter',
+          exclude: 'This.*not',
+          appender: 'recorder'
+        }
+      },
+      categories: { default: { appenders: ['filtered'], level: 'DEBUG' } }
+    });
+
+    const logger = log4js.getLogger();
+    logger.debug('This should not get logged');
+    logger.debug('This should get logged');
+    logger.debug('Another case that not match the regex, so it should get logged');
+    const logEvents = recording.replay();
+    t.equal(logEvents.length, 2);
+    t.equal(logEvents[0].data[0], 'This should get logged');
+    t.equal(logEvents[1].data[0], 'Another case that not match the regex, so it should get logged');
+    t.end();
+  });
+
+  /**
+   * test an array of regexp
+   */
+  batch.test('appender should exclude events that match the regexp string contained in the array', (t) => {
+    log4js.configure({
+      appenders: {
+        recorder: { type: 'recording' },
+        filtered: {
+          type: 'noLogFilter',
+          exclude: ['This.*not', 'instead'],
+          appender: 'recorder'
+        }
+      },
+      categories: { default: { appenders: ['filtered'], level: 'DEBUG' } }
+    });
+
+    const logger = log4js.getLogger();
+    logger.debug('This should not get logged');
+    logger.debug('This should get logged');
+    logger.debug('Another case that not match the regex, so it should get logged');
+    logger.debug('This case instead it should get logged');
+    logger.debug('The last that should get logged');
+    const logEvents = recording.replay();
+    t.equal(logEvents.length, 3);
+    t.equal(logEvents[0].data[0], 'This should get logged');
+    t.equal(logEvents[1].data[0], 'Another case that not match the regex, so it should get logged');
+    t.equal(logEvents[2].data[0], 'The last that should get logged');
+    t.end();
+  });
+  /**
+   * test case insentitive regexp
+   */
+  batch.test('appender should evaluate the regexp using incase sentitive option', (t) => {
+    log4js.configure({
+      appenders: {
+        recorder: { type: 'recording' },
+        filtered: {
+          type: 'noLogFilter',
+          exclude: ['NOT', 'eX.*de'],
+          appender: 'recorder'
+        }
+      },
+      categories: { default: { appenders: ['filtered'], level: 'DEBUG' } }
+    });
+
+    const logger = log4js.getLogger();
+
+    logger.debug('This should not get logged');
+    logger.debug('This should get logged');
+    logger.debug('Exclude this string');
+    logger.debug('Include this string');
+    const logEvents = recording.replay();
+    t.equal(logEvents.length, 2);
+    t.equal(logEvents[0].data[0], 'This should get logged');
+    t.equal(logEvents[1].data[0], 'Include this string');
+    t.end();
+  });
+
+  /**
+   * test empty string or null regexp
+   */
+  batch.test('appender should skip the match in case of empty or null regexp', (t) => {
+    log4js.configure({
+      appenders: {
+        recorder: { type: 'recording' },
+        filtered: {
+          type: 'noLogFilter',
+          exclude: ['', null, undefined],
+          appender: 'recorder'
+        }
+      },
+      categories: { default: { appenders: ['filtered'], level: 'DEBUG' } }
+    });
+
+    const logger = log4js.getLogger();
+    logger.debug('This should get logged');
+    logger.debug('Another string that should get logged');
+    const logEvents = recording.replay();
+    t.equal(logEvents.length, 2);
+    t.equal(logEvents[0].data[0], 'This should get logged');
+    t.equal(logEvents[1].data[0], 'Another string that should get logged');
+    t.end();
+  });
+
+  /**
+   * test for excluding all the events that contains digits
+   */
+  batch.test('appender should exclude the events that contains digits', (t) => {
+    log4js.configure({
+      appenders: {
+        recorder: { type: 'recording' },
+        filtered: {
+          type: 'noLogFilter',
+          exclude: '\\d',
+          appender: 'recorder'
+        }
+      },
+      categories: { default: { appenders: ['filtered'], level: 'DEBUG' } }
+    });
+
+    const logger = log4js.getLogger();
+    logger.debug('This should get logged');
+    logger.debug('The 2nd event should not get logged');
+    logger.debug('The 3rd event should not get logged, such as the 2nd');
+    const logEvents = recording.replay();
+    t.equal(logEvents.length, 1);
+    t.equal(logEvents[0].data[0], 'This should get logged');
+    t.end();
+  });
+
+  /**
+   * test the cases provided in the documentation
+   * https://log4js-node.github.io/log4js-node/noLogFilter.html
+   */
+  batch.test('appender should exclude not valid events according to the documentation', (t) => {
+    log4js.configure({
+      appenders: {
+        recorder: { type: 'recording' },
+        filtered: {
+          type: 'noLogFilter',
+          exclude: ['NOT', '\\d', ''],
+          appender: 'recorder'
+        }
+      },
+      categories: { default: { appenders: ['filtered'], level: 'DEBUG' } }
+    });
+
+    const logger = log4js.getLogger();
+    logger.debug('I will be logged in all-the-logs.log');
+    logger.debug('I will be not logged in all-the-logs.log');
+    logger.debug('A 2nd message that will be excluded in all-the-logs.log');
+    logger.debug('Hello again');
+    const logEvents = recording.replay();
+    t.equal(logEvents.length, 2);
+    t.equal(logEvents[0].data[0], 'I will be logged in all-the-logs.log');
+    t.equal(logEvents[1].data[0], 'Hello again');
+    t.end();
+  });
+
+  batch.end();
+});

--- a/types/log4js.d.ts
+++ b/types/log4js.d.ts
@@ -94,6 +94,21 @@ export interface CategoryFilterAppender {
 }
 
 /**
+ * No Log Filter
+ *
+ * @see https://log4js-node.github.io/log4js-node/noLogFilter.html
+ */
+export interface NoLogFilterAppender {
+  type: "noLogFilter";
+  // the regular expression (or the regular expressions if you provide an array of values)
+  // will be used for evaluating the events to pass to the appender. 
+  // The events, which will match the regular expression, will be excluded and so not logged. 
+  exclude: string | string[];
+  // the name of an appender, defined in the same configuration, that you want to filter.
+	appender: string;
+}
+
+/**
  * Console Appender
  *
  * @see https://log4js-node.github.io/log4js-node/console.html
@@ -228,7 +243,8 @@ export type Appender = CategoryFilterAppender
 	| FileAppender
 	| SyncfileAppender
 	| DateFileAppender
-	| LogLevelFilterAppender
+  | LogLevelFilterAppender
+  | NoLogFilterAppender
 	| MultiFileAppender
 	| MultiprocessAppender
 	| RecordingAppender


### PR DESCRIPTION
Added the feature to exclude the log events depending on the regular expression provided in the configuration.
The feature works in a similar way to the categoryFilter and logLevelFilter appenders. The log events, which will match the regular expression, will be excluded and not passed to the appender.
The regular expressions can be configured through a string or an array of strings. 
The log events will be evaluated in case-insensitive mode.
