### PR TITLE
Feature - Add status code rulesets for connectLogger

### DIFF
--- a/docs/connect-logger.md
+++ b/docs/connect-logger.md
@@ -30,6 +30,7 @@ The log4js.connectLogger supports the passing of an options object that can be u
 - log level
 - log format string or function (the same as the connect/express logger)
 - nolog expressions (represented as a string, regexp, or array)
+- status code rulesets
 
 For example:
 
@@ -55,6 +56,15 @@ Added automatic level detection to connect-logger, depends on http status respon
 
 ```javascript
 app.use(log4js.connectLogger(logger, { level: 'auto' }));
+```
+
+The levels of returned status codes can be configured via status code rulesets.
+
+```javascript
+app.use(log4js.connectLogger(logger, { level: 'auto', statusRules: [
+  { from: 200, to: 299, level: 'debug' },
+  { codes: [303, 304],  level: 'info' }
+]}));
 ```
 
 The log4js.connectLogger also supports a nolog option where you can specify a string, regexp, or array to omit certain log messages. Example of 1.2 below.

--- a/lib/connect-logger.js
+++ b/lib/connect-logger.js
@@ -166,6 +166,42 @@ function createNoLogCondition(nolog) {
 }
 
 /**
+   * Allows users to define rules around status codes to assign them to a specific
+   * logging level.
+   * There are two types of rules:
+   *   - RANGE: matches a code within a certain range
+   *     E.g. { 'from': 200, 'to': 299, 'level': 'info' }
+   *   - CONTAINS: matches a code to a set of expected codes
+   *     E.g. { 'codes': [200, 203], 'level': 'debug' }
+   * Note*: Rules are respected only in order of prescendence.
+   *
+   * @param {Number} statusCode
+   * @param {Level} currentLevel
+   * @param {Object} ruleSet
+   * @return {Level}
+   * @api private
+   */
+function matchRules(statusCode, currentLevel, ruleSet) {
+  let level = currentLevel;
+
+  if (ruleSet) {
+    const matchedRule = ruleSet.find((rule) => {
+      let ruleMatched = false;
+      if (rule.from && rule.to) {
+        ruleMatched = statusCode >= rule.from && statusCode <= rule.to;
+      } else if (rule.codes) {
+        ruleMatched = rule.codes.indexOf(statusCode) !== -1;
+      }
+      return ruleMatched;
+    });
+    if (matchedRule) {
+      level = levels.getLevel(matchedRule.level, level);
+    }
+  }
+  return level;
+}
+
+/**
    * Log requests with the given `options` or a `format` string.
    *
    * Options:
@@ -173,6 +209,7 @@ function createNoLogCondition(nolog) {
    *   - `format`        Format string, see below for tokens
    *   - `level`         A log4js levels instance. Supports also 'auto'
    *   - `nolog`         A string or RegExp to exclude target logs
+   *   - `statusRules`   A array of rules for setting specific logging levels base on status codes
    *
    * Tokens:
    *
@@ -238,6 +275,7 @@ module.exports = function getLogger(logger4js, options) {
         } else {
           level = levels.getLevel(options.level, levels.INFO);
         }
+        level = matchRules(code, level, options.statusRules);
       };
 
       // hook on end request to emit the log entry of the HTTP request.
@@ -249,6 +287,7 @@ module.exports = function getLogger(logger4js, options) {
           if (res.statusCode >= 300) level = levels.WARN;
           if (res.statusCode >= 400) level = levels.ERROR;
         }
+        level = matchRules(res.statusCode, level, options.statusRules);
 
         if (thisLogger.isLevelEnabled(level)) {
           const combinedTokens = assembleTokens(req, res, options.tokens || []);

--- a/types/log4js.d.ts
+++ b/types/log4js.d.ts
@@ -19,7 +19,7 @@ export function configure(config: Configuration): Log4js;
 
 export function addLayout(name: string, config: (a: any) => (logEvent: LoggingEvent) => string): void;
 
-export function connectLogger(logger: Logger, options: { format?: Format; level?: string; nolog?: any; }): any;	// express.Handler;
+export function connectLogger(logger: Logger, options: { format?: Format; level?: string; nolog?: any; statusRules: any[] }): any; // express.Handler;
 
 export const levels: Levels;
 

--- a/types/log4js.d.ts
+++ b/types/log4js.d.ts
@@ -19,7 +19,7 @@ export function configure(config: Configuration): Log4js;
 
 export function addLayout(name: string, config: (a: any) => (logEvent: LoggingEvent) => string): void;
 
-export function connectLogger(logger: Logger, options: { format?: Format; level?: string; nolog?: any; statusRules: any[] }): any; // express.Handler;
+export function connectLogger(logger: Logger, options: { format?: Format; level?: string; nolog?: any; statusRules?: any[] }): any; // express.Handler;
 
 export const levels: Levels;
 


### PR DESCRIPTION
When using the `connectLogger` and the level set to `auto`, logging levels are set accordingly:
* http responses 3xx, level = `WARN`
* http responses 4xx & 5xx, level = `ERROR`
* else, level = `INFO`

This general grouping does not always work however as codes such as `304 Not Modified`, which in some cases are expected, are always returned as `WARN` and cannot be assigned to `INFO` without changing it for all other codes.

This feature aims to bring in some customisability around how those levels are set by passing in `statusRules` via the `options` object. An example would be:

```javascript
app.use(log4js.connectLogger(logger, { level: 'auto', statusRules: [
  { from: 200, to: 299, level: 'debug' }, // all 2xx are logged at DEBUG
  { codes: [304],  level: 'info' }        // 304 is logged at INFO
]}));
```

There are two types of rulesets that can be defined:
  1. **Range:** All codes between `from` and `to` are set to level set on the rule
  2. **Contains:** Any specified codes are set to level set on the rule

If a status code does not match any user-defined rule, it will simply use the default level outlined either by `auto` or user-specified level.

Additional tests have been added to `connect-logger-test.js`