### PR TITLE
Improve connect logger coverage

### DIFF
--- a/lib/connect-logger.js
+++ b/lib/connect-logger.js
@@ -79,7 +79,7 @@ function assembleTokens(req, res, customTokens) {
   defaultTokens.push({ token: ':user-agent', replacement: req.headers['user-agent'] });
   defaultTokens.push({
     token: ':content-length',
-    replacement: (res._headers && res._headers['content-length']) ||
+    replacement: res.getHeader('content-length') ||
       (res.__headers && res.__headers['Content-Length']) ||
       '-'
   });
@@ -92,9 +92,7 @@ function assembleTokens(req, res, customTokens) {
   defaultTokens.push({
     token: /:res\[([^\]]+)]/g,
     replacement: function (_, field) {
-      return res._headers ?
-        (res._headers[field.toLowerCase()] || res.__headers[field])
-        : (res.__headers && res.__headers[field]);
+      return res.getHeader(field.toLowerCase()) || (res.__headers && res.__headers[field]);
     }
   });
 
@@ -262,16 +260,6 @@ module.exports = function getLogger(logger4js, options) {
 
         res.__statusCode = code;
         res.__headers = headers || {};
-
-        // status code response level handling
-        if (options.level === 'auto') {
-          level = levels.INFO;
-          if (code >= 300) level = levels.WARN;
-          if (code >= 400) level = levels.ERROR;
-        } else {
-          level = levels.getLevel(options.level, levels.INFO);
-        }
-        level = matchRules(code, level, options.statusRules);
       };
 
       // hook on end request to emit the log entry of the HTTP request.

--- a/lib/connect-logger.js
+++ b/lib/connect-logger.js
@@ -146,20 +146,18 @@ function format(str, tokens) {
 function createNoLogCondition(nolog) {
   let regexp = null;
 
-  if (nolog) {
-    if (nolog instanceof RegExp) {
-      regexp = nolog;
-    }
+  if (nolog instanceof RegExp) {
+    regexp = nolog;
+  }
 
-    if (typeof nolog === 'string') {
-      regexp = new RegExp(nolog);
-    }
+  if (typeof nolog === 'string') {
+    regexp = new RegExp(nolog);
+  }
 
-    if (Array.isArray(nolog)) {
-      // convert to strings
-      const regexpsAsStrings = nolog.map(reg => (reg.source ? reg.source : reg));
-      regexp = new RegExp(regexpsAsStrings.join('|'));
-    }
+  if (Array.isArray(nolog)) {
+    // convert to strings
+    const regexpsAsStrings = nolog.map(reg => (reg.source ? reg.source : reg));
+    regexp = new RegExp(regexpsAsStrings.join('|'));
   }
 
   return regexp;
@@ -189,7 +187,7 @@ function matchRules(statusCode, currentLevel, ruleSet) {
       let ruleMatched = false;
       if (rule.from && rule.to) {
         ruleMatched = statusCode >= rule.from && statusCode <= rule.to;
-      } else if (rule.codes) {
+      } else {
         ruleMatched = rule.codes.indexOf(statusCode) !== -1;
       }
       return ruleMatched;
@@ -232,18 +230,16 @@ function matchRules(statusCode, currentLevel, ruleSet) {
    */
 module.exports = function getLogger(logger4js, options) {
   /* eslint no-underscore-dangle:0 */
-  if (typeof options === 'object') {
-    options = options || {};
-  } else if (options) {
+  if (typeof options === 'string' || typeof options === 'function') {
     options = { format: options };
   } else {
-    options = {};
+    options = options || {};
   }
 
   const thisLogger = logger4js;
   let level = levels.getLevel(options.level, levels.INFO);
   const fmt = options.format || DEFAULT_FORMAT;
-  const nolog = options.nolog ? createNoLogCondition(options.nolog) : null;
+  const nolog = createNoLogCondition(options.nolog);
 
   return (req, res, next) => {
     // mount safety
@@ -289,15 +285,13 @@ module.exports = function getLogger(logger4js, options) {
         }
         level = matchRules(res.statusCode, level, options.statusRules);
 
-        if (thisLogger.isLevelEnabled(level)) {
-          const combinedTokens = assembleTokens(req, res, options.tokens || []);
+        const combinedTokens = assembleTokens(req, res, options.tokens || []);
 
-          if (typeof fmt === 'function') {
-            const line = fmt(req, res, str => format(str, combinedTokens));
-            if (line) thisLogger.log(level, line);
-          } else {
-            thisLogger.log(level, format(fmt, combinedTokens));
-          }
+        if (typeof fmt === 'function') {
+          const line = fmt(req, res, str => format(str, combinedTokens));
+          if (line) thisLogger.log(level, line);
+        } else {
+          thisLogger.log(level, format(fmt, combinedTokens));
         }
       });
     }

--- a/test/tap/connect-logger-test.js
+++ b/test/tap/connect-logger-test.js
@@ -37,15 +37,22 @@ function MockRequest(remoteAddr, method, originalUrl, headers, url) {
 class MockResponse extends EE {
   constructor() {
     super();
-    const r = this;
-    this.end = function () {
-      r.emit('finish');
-    };
+    this.cachedHeaders = {};
+  }
+  end() {
+    this.emit('finish');
+  }
 
-    this.writeHead = function (code, headers) {
-      this.statusCode = code;
-      this._headers = headers;
-    };
+  setHeader(key, value) {
+    this.cachedHeaders[key.toLowerCase()] = value;
+  }
+
+  getHeader(key) {
+    return this.cachedHeaders[key.toLowerCase()];
+  }
+
+  writeHead(code /* , headers */) {
+    this.statusCode = code;
   }
 }
 
@@ -327,6 +334,21 @@ test('log4js connect logger', (batch) => {
     t.equal(ml.messages.length, 1);
     t.ok(levels.INFO.isEqualTo(ml.messages[0].level));
     t.equal(ml.messages[0].message, 'GET http://url 20150310');
+    t.end();
+  });
+
+  batch.test('handle weird old node versions where socket contains socket', (t) => {
+    const ml = new MockLogger();
+    const cl = clm(ml, ':remote-addr');
+    const req = new MockRequest(null, 'GET', 'http://blah');
+    req.socket = { socket: { remoteAddress: 'this is weird' } };
+
+    const res = new MockResponse();
+    cl(req, res, () => {});
+    res.writeHead(200, {});
+    res.end('chunk', 'encoding');
+
+    t.equal(ml.messages[0].message, 'this is weird');
     t.end();
   });
 

--- a/test/tap/connect-nolog-test.js
+++ b/test/tap/connect-nolog-test.js
@@ -29,14 +29,25 @@ function MockRequest(remoteAddr, method, originalUrl) {
 }
 
 class MockResponse extends EE {
-  constructor(statusCode) {
+  constructor(code) {
     super();
-    const r = this;
-    this.statusCode = statusCode;
+    this.statusCode = code;
+    this.cachedHeaders = {};
+  }
+  end() {
+    this.emit('finish');
+  }
 
-    this.end = function () {
-      r.emit('finish');
-    };
+  setHeader(key, value) {
+    this.cachedHeaders[key.toLowerCase()] = value;
+  }
+
+  getHeader(key) {
+    return this.cachedHeaders[key.toLowerCase()];
+  }
+
+  writeHead(code /* , headers */) {
+    this.statusCode = code;
   }
 }
 

--- a/test/tap/connect-nolog-test.js
+++ b/test/tap/connect-nolog-test.js
@@ -221,5 +221,52 @@ test('log4js connect logger', (batch) => {
     t.end();
   });
 
+  batch.test('nolog Array<RegExp>', (t) => {
+    const ml = new MockLogger();
+    const cl = clm(ml, { nolog: [/\.gif/, /\.jpe?g/] });
+
+    t.beforeEach((done) => { ml.messages = []; done(); });
+
+    t.test('check unmatch url request (png)', (assert) => {
+      const messages = ml.messages;
+      const req = new MockRequest('my.remote.addr', 'GET', 'http://url/hoge.png'); // not gif
+      const res = new MockResponse(200);
+      cl(req, res, () => { });
+      res.end('chunk', 'encoding');
+
+      assert.equal(messages.length, 1);
+      assert.ok(levels.INFO.isEqualTo(messages[0].level));
+      assert.include(messages[0].message, 'GET');
+      assert.include(messages[0].message, 'http://url');
+      assert.include(messages[0].message, 'my.remote.addr');
+      assert.include(messages[0].message, '200');
+      assert.end();
+    });
+
+    t.test('check match url request (gif)', (assert) => {
+      const messages = ml.messages;
+      const req = new MockRequest('my.remote.addr', 'GET', 'http://url/hoge.gif'); // gif
+      const res = new MockResponse(200);
+      cl(req, res, () => {});
+      res.end('chunk', 'encoding');
+
+      assert.equal(messages.length, 0);
+      assert.end();
+    });
+
+    t.test('check match url request (jpeg)', (assert) => {
+      const messages = ml.messages;
+      const req = new MockRequest('my.remote.addr', 'GET', 'http://url/hoge.jpeg'); // gif
+      const res = new MockResponse(200);
+      cl(req, res, () => {});
+      res.end('chunk', 'encoding');
+
+      assert.equal(messages.length, 0);
+      assert.end();
+    });
+
+    t.end();
+  });
+
   batch.end();
 });


### PR DESCRIPTION
I started off just adding tests to cover cases which had been missed, but I also replaced the non-standard `res._headers` with `res.getHeader()`, and removed code which wasn't used.