### PR TITLE
feature: adding the option to provide appender instance in config

### DIFF
--- a/lib/appenders/index.js
+++ b/lib/appenders/index.js
@@ -39,7 +39,8 @@ const loadAppenderModule = (type, config) => coreAppenders.get(type) ||
 
 const createAppender = (name, config) => {
   const appenderConfig = config.appenders[name];
-  const appenderModule = loadAppenderModule(appenderConfig.type, config);
+  const appenderModule =
+    appenderConfig.type.configure ? appenderConfig.type : loadAppenderModule(appenderConfig.type, config);
   configuration.throwExceptionIf(
     config,
     configuration.not(appenderModule),

--- a/test/tap/configuration-validation-test.js
+++ b/test/tap/configuration-validation-test.js
@@ -226,6 +226,26 @@ test('log4js configuration validation', (batch) => {
     t.end();
   });
 
+  batch.test('should use provided appender instance if instance provided', (t) => {
+    const thing = {};
+    const cheese = testAppender('cheesy', thing);
+    const sandboxedLog4js = sandbox.require(
+      '../../lib/log4js',
+      {
+        ignoreMissing: true
+      }
+    );
+
+    sandboxedLog4js.configure({
+      appenders: { thing: { type: cheese } },
+      categories: { default: { appenders: ['thing'], level: 'ERROR' } }
+    });
+
+    t.ok(thing.configureCalled);
+    t.same(thing.type, cheese);
+    t.end();
+  });
+
   batch.test('should not throw error if configure object is freezed', (t) => {
     t.doesNotThrow(() => log4js.configure(deepFreeze({
       appenders: {


### PR DESCRIPTION
This PR is related to issue https://github.com/log4js-node/log4js-node/issues/832.
It adds the ability to supply an appender instance (instead of just a string name) when specifying a configuration. 