### PR TITLE
Allow anything in the addLayout

### DIFF
--- a/types/log4js.d.ts
+++ b/types/log4js.d.ts
@@ -17,7 +17,7 @@ export function getLogger(category?: string): Logger;
 export function configure(filename: string): Log4js;
 export function configure(config: Configuration): Log4js;
 
-export function addLayout(name: string, config: (a: any) => (logEvent: LoggingEvent) => string): void;
+export function addLayout(name: string, config: (a: any) => (logEvent: LoggingEvent) => any): void;
 
 export function connectLogger(logger: Logger, options: { format?: Format; level?: string; nolog?: any; statusRules?: any[] }): any; // express.Handler;
 


### PR DESCRIPTION
per https://github.com/log4js-node/log4js-node/blob/master/docs/layouts.md
 

# Adding your own layouts

You can add your own layouts by calling `log4js.addLayout(type, fn)` before calling `log4js.configure`. `type` is the label you want to use to refer to your layout in appender configuration. `fn` is a function that takes a single object argument, which will contain the configuration for the layout instance, and returns a layout function. A layout function takes a log event argument and **returns a string (usually, although you could return anything as long as the appender knows what to do with it).**