### PR TITLE
fix(layout): Use level as a string for node v12

### DIFF
--- a/lib/layouts.js
+++ b/lib/layouts.js
@@ -45,7 +45,7 @@ function timestampLevelAndCategory(loggingEvent, colour) {
     util.format(
       '[%s] [%s] %s - ',
       dateFormat.asString(loggingEvent.startTime),
-      loggingEvent.level,
+      loggingEvent.level.toString(),
       loggingEvent.categoryName
     ),
     colour


### PR DESCRIPTION
Fixes #859

I would add tests for node v12, but there are a number of unrelated failures. I'll take a stab at getting the tests to pass under node v12 on a different PR. This one can solve the immediate problem that will stop log4js users from upgrading to node v12.
