### PR TITLE
fix: test failed when tap >= 13

### DIFF
--- a/test/tap/configuration-validation-test.js
+++ b/test/tap/configuration-validation-test.js
@@ -232,6 +232,7 @@ test('log4js configuration validation', (batch) => {
       ignoreMissing: true,
       requires: {}
     };
+    sandboxConfig.requires['./cheese'] = testAppender('correct', result);
     sandboxConfig.requires[`${mainPath}/cheese`] = testAppender('correct', result);
     // add this one, because when we're running coverage the main path is a bit different
     sandboxConfig.requires[


### PR DESCRIPTION
when tap >= 13, test will fail
```bash
 FAIL  test/tap/configuration-validation-test.js
Problem with log4js configuration: ({ appenders: { thing: { type: 'cheese' } },   categories: { default: { appenders: [ 'thing' ], level: 'ERROR' } } }) - appender "thing" is not valid (type "cheese" could not be found)

  stack: |
    tests.forEach.test (lib/configuration.js:917:13)
    Array.forEach (<anonymous>)
    Object.throwExceptionIf (lib/configuration.js:910:9)
    createAppender (lib/appenders/index.js:1025:17)
    Object.keys.forEach.name (lib/appenders/index.js:1079:25)
    Array.forEach (<anonymous>)
    setup (lib/appenders/index.js:1074:33)
    listeners.forEach.listener (lib/configuration.js:950:12)
    Array.forEach (<anonymous>)
    Object.configure (lib/configuration.js:947:13)
  at:
    line: 917
    column: 13
    file: lib/configuration.js
    function: tests.forEach.test
  tapCaught: testFunctionThrow
  test: should load appenders relative to main file if not in core, or node_modules
```