### PR TITLE
fix: loglevelfilter was missing from core appenders

### DIFF
--- a/lib/appenders/index.js
+++ b/lib/appenders/index.js
@@ -11,6 +11,9 @@ const coreAppenders = new Map();
 coreAppenders.set('console', require('./console'));
 coreAppenders.set('stdout', require('./stdout'));
 coreAppenders.set('stderr', require('./stderr'));
+coreAppenders.set('logLevelFilter', require('./logLevelFilter'));
+coreAppenders.set('categoryFilter', require('./categoryFilter'));
+coreAppenders.set('noLogFilter', require('./noLogFilter'));
 coreAppenders.set('file', require('./file'));
 coreAppenders.set('dateFile', require('./dateFile'));
 


### PR DESCRIPTION
This is a fix for #816 that got completely forgotten about as far as I can tell. Sorry.