### PR TITLE
[enhancement]Emmit pause event for node js when buffer is full

### DIFF
--- a/lib/appenders/file.js
+++ b/lib/appenders/file.js
@@ -15,6 +15,9 @@ function openTheStream(file, fileSize, numFiles, options) {
   stream.on('error', (err) => {
     console.error('log4js.fileAppender - Writing to file %s, error happened ', file, err); //eslint-disable-line
   });
+  stream.on('drain', () => {
+    process.emit("pause", false);
+  });
   return stream;
 }
 
@@ -50,7 +53,9 @@ function fileAppender(file, layout, logSize, numBackups, options, timezoneOffset
   let writer = openTheStream(file, logSize, numBackups, options);
 
   const app = function (loggingEvent) {
-    writer.write(layout(loggingEvent, timezoneOffset) + eol, 'utf8');
+    if (!writer.write(layout(loggingEvent, timezoneOffset) + eol, "utf8")) {
+      process.emit('pause', true);
+    }
   };
 
   app.reopen = function () {

--- a/lib/appenders/file.js
+++ b/lib/appenders/file.js
@@ -16,7 +16,7 @@ function openTheStream(file, fileSize, numFiles, options) {
     console.error('log4js.fileAppender - Writing to file %s, error happened ', file, err); //eslint-disable-line
   });
   stream.on('drain', () => {
-    process.emit("pause", false);
+    process.emit("log4js:pause", false);
   });
   return stream;
 }
@@ -54,7 +54,7 @@ function fileAppender(file, layout, logSize, numBackups, options, timezoneOffset
 
   const app = function (loggingEvent) {
     if (!writer.write(layout(loggingEvent, timezoneOffset) + eol, "utf8")) {
-      process.emit('pause', true);
+      process.emit('log4js:pause', true);
     }
   };
 

--- a/test/tap/pause-test.js
+++ b/test/tap/pause-test.js
@@ -17,7 +17,7 @@ tap.test("Drain event test", batch => {
     let onPause = false;
     let onResume = false;
 
-    process.on("pause", value => {
+    process.on("log4js:pause", value => {
       if (value) {
         onPause = true;
       } else {

--- a/test/tap/pause-test.js
+++ b/test/tap/pause-test.js
@@ -1,0 +1,37 @@
+const tap = require("tap");
+const log4js = require("../../lib/log4js");
+
+tap.test("Drain event test", batch => {
+
+  batch.test("Should emit pause event and resume when logging in a file with high frequency", t => {
+    // Generate logger with 5MB of highWaterMark config
+    log4js.configure({
+      appenders: {
+        file: { type: "file", filename: "logs/drain.log", highWaterMark: 5 * 1024 * 1024 }
+      },
+      categories: {
+        default: { appenders: ["file"], level: "debug" }
+      }
+    });
+
+    let onPause = false;
+    let onResume = false;
+
+    process.on("pause", value => {
+      if (value) {
+        onPause = true;
+      } else {
+        onResume = true;
+      }
+    });
+
+    const logger = log4js.getLogger();
+    while (onPause === false && onResume === false) {
+      if (onPause === false)
+        logger.info("This is a test for emitting drain event");
+    }
+    t.end();
+  });
+
+  batch.end();
+});


### PR DESCRIPTION
Hi,

I made some change in file.js module, so when the buffer is full the 'pause' event will emit, and after now we can listen to this event. When this event is emitted we can stop logging or maybe send 'server too busy' response and wait till the drain event emitted. With these changes logger will not stop and just an event emitted, and this is possible if someone want to continue logging.