### PR TITLE
fix: updated streamroller to improve windows log rolling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -636,9 +636,9 @@
       }
     },
     "commander": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.1.tgz",
+      "integrity": "sha512-cCuLsMhJeWQ/ZpsFTbE765kvVfoeSddc4nU3up4fV+fDBcfUXnbITJ+JzhkdjzOqhURjZgujxaioam4RM9yGUg==",
       "dev": true,
       "optional": true
     },
@@ -1620,9 +1620,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
-      "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.2.tgz",
+      "integrity": "sha512-cIv17+GhL8pHHnRJzGu2wwcthL5sb8uDKBHvZ2Dtu5s1YNt0ljbzKbamnc+gr69y7bzwQiBdr5+hOpRd5pnOdg==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -3523,9 +3523,9 @@
       "dev": true
     },
     "streamroller": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-2.1.0.tgz",
-      "integrity": "sha512-Ps7CuQL0RRG0YAigxNehrGfHrLu+jKSSnhiZBwF8uWi62WmtHDQV1OG5gVgV5SAzitcz1GrM3QVgnRO0mXV2hg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-2.2.0.tgz",
+      "integrity": "sha512-0CTjQK2fHo/qAUMoCd/J5BvxqoPyAQFaMorv2Z4cxjLYPYRn0Q9PG8Z7LHvyK2mDHSpeS9R7AvMr0vSI/Mq0HA==",
       "requires": {
         "date-format": "^2.1.0",
         "debug": "^4.1.1",
@@ -5082,7 +5082,7 @@
     "universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+      "integrity": "sha1-tkb2m+OULavOzJ1mOcgNwQXvqmY="
     },
     "uri-js": {
       "version": "4.2.2",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "debug": "^4.1.1",
     "flatted": "^2.0.1",
     "rfdc": "^1.1.4",
-    "streamroller": "^2.1.0"
+    "streamroller": "^2.2.0"
   },
   "devDependencies": {
     "@log4js-node/sandboxed-module": "^2.2.1",


### PR DESCRIPTION
Streamroller 2.2.0 falls back to copy and truncate when a file is busy. This can happen if someone it tailing a log file, for instance, while we're trying to rename and delete it.