### PR TITLE
fix: update streamroller to handle date patterns that are all digits

### DIFF
--- a/examples/date-file-rolling.js
+++ b/examples/date-file-rolling.js
@@ -5,7 +5,7 @@ const log4js = require('../lib/log4js');
 log4js.configure({
   appenders: {
     file: {
-      type: 'dateFile', filename: 'thing.log', pattern: '.ss'
+      type: 'dateFile', filename: 'thing.log', daysToKeep: 3, pattern: '.mm'
     }
   },
   categories: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3523,9 +3523,9 @@
       "dev": true
     },
     "streamroller": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-2.2.0.tgz",
-      "integrity": "sha512-0CTjQK2fHo/qAUMoCd/J5BvxqoPyAQFaMorv2Z4cxjLYPYRn0Q9PG8Z7LHvyK2mDHSpeS9R7AvMr0vSI/Mq0HA==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-2.2.1.tgz",
+      "integrity": "sha512-LkKpmGNQwHWGqvG4h6v/IEz3s+EoR/0PSX8q5Mv4yXlFWxxp3I6zGv/maCSzyFzbfWmm5HQdoZvrrPyHjxzg1Q==",
       "requires": {
         "date-format": "^2.1.0",
         "debug": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "debug": "^4.1.1",
     "flatted": "^2.0.1",
     "rfdc": "^1.1.4",
-    "streamroller": "^2.2.0"
+    "streamroller": "^2.2.1"
   },
   "devDependencies": {
     "@log4js-node/sandboxed-module": "^2.2.1",


### PR DESCRIPTION
This should help at least some of the problems in #836 - if the dateFile pattern is all digits, then streamroller was getting confused with the index part of the file name and not deleting old files.