### PR TITLE
fix: update streamroller to fix #906

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3523,9 +3523,9 @@
       "dev": true
     },
     "streamroller": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-2.2.1.tgz",
-      "integrity": "sha512-LkKpmGNQwHWGqvG4h6v/IEz3s+EoR/0PSX8q5Mv4yXlFWxxp3I6zGv/maCSzyFzbfWmm5HQdoZvrrPyHjxzg1Q==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-2.2.2.tgz",
+      "integrity": "sha512-wizmZ8NNiqeNIYHv8MqBBbSIeNNcsXyoKxbGYBpiFHCjTGlNHqGNGElwrSM3Awg+0j6U96/eFrSnjW+h3aRo0Q==",
       "requires": {
         "date-format": "^2.1.0",
         "debug": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "debug": "^4.1.1",
     "flatted": "^2.0.1",
     "rfdc": "^1.1.4",
-    "streamroller": "^2.2.1"
+    "streamroller": "^2.2.2"
   },
   "devDependencies": {
     "@log4js-node/sandboxed-module": "^2.2.1",


### PR DESCRIPTION
Streamroller 2.2.2 includes this [change](https://github.com/log4js-node/streamroller/pull/54) which should fix the problem in #906 where date files overwrite the current log on restart.