### PR TITLE
fix: truncation and padding for stacktraces

### DIFF
--- a/docs/layouts.md
+++ b/docs/layouts.md
@@ -99,8 +99,16 @@ Cheese is too ripe! Cheese was:
 
 ## Pattern format
 The pattern string can contain any characters, but sequences beginning with `%` will be replaced with values taken from the log event, and other environmental values.
-Format for specifiers is `%[padding].[truncation][field]{[format]}` - padding and truncation are optional, and format only applies to a few tokens (notably, date).
-e.g. %5.10p - left pad the log level by 5 characters, up to a max of 10
+Format for specifiers is `%[padding].[truncation][field]{[format]}` - padding and truncation are optional, and format only applies to a few tokens (notably, date). Both padding and truncation values can be negative.
+* Positive truncation - truncate the string starting from the beginning
+* Negative truncation - truncate the string starting from the end of the string
+* Positive padding - left pad the string to make it this length, if the string is longer than the padding value then nothing happens
+* Negative padding - right pad the string to make it this length, if the string is longer than the padding value then nothing happens
+To make fixed-width columns in your log output, set padding and truncation to the same size (they don't have to have the same sign though, you could have right truncated, left padded columns that are always 10 characters wide with a pattern like "%10.-10m").
+
+e.g. %5.10p - left pad the log level by up to 5 characters, keep the whole string to a max length of 10.
+So, for a log level of INFO the output would be " INFO", for DEBUG it would be "DEBUG" and for a (custom) log level of CATASTROPHIC it would be "CATASTROPH".
+
 
 Fields can be any of:
 *  `%r` time in toLocaleTimeString format

--- a/examples/stacktrace.js
+++ b/examples/stacktrace.js
@@ -1,0 +1,22 @@
+const log4js = require('../lib/log4js');
+
+log4js.configure({
+  "appenders": {
+    "console-appender": {
+      "type": "console",
+      "layout": {
+        "type": "pattern",
+        "pattern": "%[[%p]%] - %10.-100f{2} | %7.12l:%7.12o - %[%m%]"
+      }
+    }
+  },
+  "categories": {
+    "default": {
+      "appenders": ["console-appender"],
+      "enableCallStack": true,
+      "level": "info"
+    }
+  }
+})
+
+log4js.getLogger().info('This should not cause problems');

--- a/lib/layouts.js
+++ b/lib/layouts.js
@@ -82,6 +82,12 @@ function dummyLayout(loggingEvent) {
  * PatternLayout
  * Format for specifiers is %[padding].[truncation][field]{[format]}
  * e.g. %5.10p - left pad the log level by 5 characters, up to a max of 10
+ * both padding and truncation can be negative.
+ * Negative truncation = trunc from end of string
+ * Positive truncation = trunc from start of string
+ * Negative padding = pad right
+ * Positive padding = pad left
+ *
  * Fields can be any of:
  *  - %r time in toLocaleTimeString format
  *  - %p log level
@@ -117,7 +123,7 @@ function dummyLayout(loggingEvent) {
  */
 function patternLayout(pattern, tokens) {
   const TTCC_CONVERSION_PATTERN = '%r %p %c - %m%n';
-  const regex = /%(-?[0-9]+)?(\.?[0-9]+)?([[\]cdhmnprzxXyflos%])(\{([^}]+)\})?|([^%]+)/;
+  const regex = /%(-?[0-9]+)?(\.?-?[0-9]+)?([[\]cdhmnprzxXyflos%])(\{([^}]+)\})?|([^%]+)/;
 
   pattern = pattern || TTCC_CONVERSION_PATTERN;
 
@@ -227,11 +233,11 @@ function patternLayout(pattern, tokens) {
   }
 
   function lineNumber(loggingEvent) {
-    return loggingEvent.lineNumber || '';
+    return loggingEvent.lineNumber ? `${loggingEvent.lineNumber}` : '';
   }
 
   function columnNumber(loggingEvent) {
-    return loggingEvent.columnNumber || '';
+    return loggingEvent.columnNumber ? `${loggingEvent.columnNumber}` : '';
   }
 
   function callStack(loggingEvent) {
@@ -268,7 +274,8 @@ function patternLayout(pattern, tokens) {
     let len;
     if (truncation) {
       len = parseInt(truncation.substr(1), 10);
-      return toTruncate.substring(0, len);
+      // negative truncate length means truncate from end of string
+      return len > 0 ? toTruncate.slice(0, len) : toTruncate.slice(len);
     }
 
     return toTruncate;

--- a/test/tap/layouts-test.js
+++ b/test/tap/layouts-test.js
@@ -521,13 +521,38 @@ test("log4js layouts", batch => {
       assert.end();
     });
 
+    t.test("%f should accept truncation and padding", assert => {
+      testPattern(assert, layout, event, tokens, "%.5f", fileName.substring(0, 5));
+      testPattern(assert, layout, event, tokens, "%20f{1}", "     layouts-test.js");
+      testPattern(assert, layout, event, tokens, "%30.30f{2}", `           ${  path.join("tap","layouts-test.js")}`);
+      testPattern(assert, layout, event, tokens, "%10.-5f{1}", "     st.js");
+      assert.end();
+    });
+
     t.test("%l should output line number", assert => {
       testPattern(assert, layout, event, tokens, "%l", lineNumber.toString());
       assert.end();
     });
 
+    t.test("%l should accept truncation and padding", assert => {
+      testPattern(assert, layout, event, tokens, "%5.10l", "    1");
+      testPattern(assert, layout, event, tokens, "%.5l", "1");
+      testPattern(assert, layout, event, tokens, "%.-5l", "1");
+      testPattern(assert, layout, event, tokens, "%-5l", "1    ");
+      assert.end();
+    });
+
     t.test("%o should output column postion", assert => {
       testPattern(assert, layout, event, tokens, "%o", columnNumber.toString());
+      assert.end();
+    });
+
+    t.test("%o should accept truncation and padding", assert => {
+      testPattern(assert, layout, event, tokens, "%5.10o", "   14");
+      testPattern(assert, layout, event, tokens, "%.5o", "14");
+      testPattern(assert, layout, event, tokens, "%.1o", "1");
+      testPattern(assert, layout, event, tokens, "%.-1o", "4");
+      testPattern(assert, layout, event, tokens, "%-5o", "14   ");
       assert.end();
     });
 
@@ -552,7 +577,7 @@ test("log4js layouts", batch => {
     );
 
     t.test(
-      "%o should output empty string when culumnNumber not exist",
+      "%o should output empty string when columnNumber not exist",
       assert => {
         delete event.columnNumber;
         testPattern(assert, layout, event, tokens, "%o", "");
@@ -611,6 +636,7 @@ test("log4js layouts", batch => {
         "%.2919102m",
         "this is a test"
       );
+      testPattern(assert, layout, event, tokens, "%.-4m", "test");
       assert.end();
     });
 


### PR DESCRIPTION
This fixes the errors found in #955, and also adds negative truncation (allowing you to truncate fields from the end of the string instead of the start).