### PR TITLE
Ignore .bob when publishing

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -16,3 +16,4 @@ Gemfile
 Gemfile.lock
 docker-compose.yml
 Dockerfile
+.bob


### PR DESCRIPTION
We noticed that .bob was in our production container 

```
du -k node_modules/* | awk '$1 > 2000' | sort -nr 
2648	node_modules/log4js/.bob
2632	node_modules/log4js/.bob/complexity
2624	node_modules/log4js/.bob/complexity/plato
```

Since .bob is in the .gitignore and only referenced in the tests https://github.com/log4js-node/log4js-node/blob/5545f2a932e012177e553bfda90d8b3fba80b332/test/tap/LoggingEvent-test.js#L19 we figured you might want to add it to the .npmignore