### PR TITLE
chore: update streamroller to 2.2.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -263,7 +263,7 @@
     "asn1": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "integrity": "sha1-jSR136tVO7M+d7VOWeiAu4ziMTY=",
       "dev": true,
       "requires": {
         "safer-buffer": "~2.1.0"
@@ -332,7 +332,7 @@
     "bind-obj-methods": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/bind-obj-methods/-/bind-obj-methods-2.0.0.tgz",
-      "integrity": "sha512-3/qRXczDi2Cdbz6jE+W3IflJOutRVica8frpBn14de1mBOkzDo+6tY33kNhvkw54Kn3PzRRD2VnGbGPcTAk4sw==",
+      "integrity": "sha1-AXgUDb57e7Z9x0iSrOWbwCR/BvA=",
       "dev": true
     },
     "brace-expansion": {
@@ -363,7 +363,7 @@
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "integrity": "sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8=",
       "dev": true
     },
     "builtin-modules": {
@@ -552,7 +552,7 @@
     "color-support": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "integrity": "sha1-k4NDeaHMmgxh+C9S8NBDIiUb1aI=",
       "dev": true
     },
     "colors": {
@@ -1140,7 +1140,7 @@
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo=",
       "dev": true
     },
     "external-editor": {
@@ -1389,7 +1389,7 @@
     "form-data": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "integrity": "sha1-3M5SwF9kTymManq5Nr1yTO/786Y=",
       "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
@@ -1524,7 +1524,7 @@
     "har-validator": {
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+      "integrity": "sha1-HvievT5JllV2de7ZiTEQ3DUPoIA=",
       "dev": true,
       "requires": {
         "ajv": "^6.5.5",
@@ -2273,7 +2273,7 @@
     "log-driver": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
-      "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
+      "integrity": "sha1-Y7lQIfBwL+36LJuwok53l9cYcdg=",
       "dev": true
     },
     "loose-envify": {
@@ -2587,7 +2587,7 @@
     "oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "integrity": "sha1-R6ewFrqmi1+g7PPe4IqFxnmsZFU=",
       "dev": true
     },
     "object-assign": {
@@ -2665,7 +2665,7 @@
     "opener": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.1.tgz",
-      "integrity": "sha512-goYSy5c2UXE4Ra1xixabeVh1guIX/ZV/YokJksb6q2lubWu6UbvPQ20p542/sFIll1nl8JnCyK9oBaOcCWXwvA==",
+      "integrity": "sha1-bS8Od/GgrwAyrKcWwsH7uOfoq+0=",
       "dev": true
     },
     "optionator": {
@@ -2714,7 +2714,7 @@
     "own-or-env": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/own-or-env/-/own-or-env-1.0.1.tgz",
-      "integrity": "sha512-y8qULRbRAlL6x2+M0vIe7jJbJx/kmUTzYonRAa2ayesR2qWLswninkVyeJe4x3IEXhdgoNodzjQRKAoEs6Fmrw==",
+      "integrity": "sha1-VM5gHTv3gjbFxlYzqhyOwD+AB+Q=",
       "dev": true,
       "requires": {
         "own-or": "^1.0.0"
@@ -2968,7 +2968,7 @@
     "qs": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+      "integrity": "sha1-yzroBuh0BERYTvFUzo7pjUA/PjY=",
       "dev": true
     },
     "react": {
@@ -3365,7 +3365,7 @@
     "stack-utils": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
-      "integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==",
+      "integrity": "sha1-M+ujiXeIVYvr/C2wWdwVjsNs67g=",
       "dev": true
     },
     "stream-events": {
@@ -3378,9 +3378,9 @@
       }
     },
     "streamroller": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-2.2.3.tgz",
-      "integrity": "sha512-AegmvQsscTRhHVO46PhCDerjIpxi7E+d2GxgUDu+nzw/HuLnUdxHWr6WQ+mVn/4iJgMKKFFdiUwFcFRDvcjCtw==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-2.2.4.tgz",
+      "integrity": "sha512-OG79qm3AujAM9ImoqgWEY1xG4HX+Lw+yY6qZj9R1K2mhF5bEmQ849wvrb+4vt4jLMLzwXttJlQbOdPOQVRv7DQ==",
       "requires": {
         "date-format": "^2.1.0",
         "debug": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "debug": "^4.1.1",
     "flatted": "^2.0.1",
     "rfdc": "^1.1.4",
-    "streamroller": "^2.2.3"
+    "streamroller": "^2.2.4"
   },
   "devDependencies": {
     "@log4js-node/sandboxed-module": "^2.2.1",


### PR DESCRIPTION
Streamroller 2.2.4 contains a fix for incorrect filename matching when cleaning up old files.