### PR TITLE
Added support for removing embedded ANSI color sequence for file appender

### DIFF
--- a/lib/appenders/file.js
+++ b/lib/appenders/file.js
@@ -55,12 +55,8 @@ function fileAppender(file, layout, logSize, numBackups, options, timezoneOffset
   const app = function (loggingEvent) {
     if (options.removeColor === true) {
       // eslint-disable-next-line no-control-regex
-      const regex = new RegExp("\x1b[[0-9;]*m", "g");
-      for (let i = 0; i < loggingEvent.data.length; i += 1) {
-        let d = loggingEvent.data[i];
-        d = d.replace(regex, '');
-        loggingEvent.data[i] = d;
-      }
+      const regex = /\x1b[[0-9;]*m/g;
+      loggingEvent.data = loggingEvent.data.map(d => d.replace(regex, ''))
     }
     if (!writer.write(layout(loggingEvent, timezoneOffset) + eol, "utf8")) {
       process.emit('log4js:pause', true);

--- a/lib/appenders/file.js
+++ b/lib/appenders/file.js
@@ -58,7 +58,7 @@ function fileAppender(file, layout, logSize, numBackups, options, timezoneOffset
       const regex = /\x1b[[0-9;]*m/g;
       loggingEvent.data = loggingEvent.data.map(d => {
         if (typeof d === 'string') return d.replace(regex, '')
-        else return d
+        return d
       })
     }
     if (!writer.write(layout(loggingEvent, timezoneOffset) + eol, "utf8")) {

--- a/lib/appenders/file.js
+++ b/lib/appenders/file.js
@@ -53,6 +53,15 @@ function fileAppender(file, layout, logSize, numBackups, options, timezoneOffset
   let writer = openTheStream(file, logSize, numBackups, options);
 
   const app = function (loggingEvent) {
+    if (options.removeColor === true) {
+      let data = loggingEvent.data
+      for (let i = 0; i < data.length; i++) {
+        let d = data[i]
+        d = d.replace(/\x1b\[[0-9]{1,2}m/g, '')
+        data[i] = d
+      }
+      loggingEvent.data = data
+    }
     if (!writer.write(layout(loggingEvent, timezoneOffset) + eol, "utf8")) {
       process.emit('log4js:pause', true);
     }

--- a/lib/appenders/file.js
+++ b/lib/appenders/file.js
@@ -54,7 +54,9 @@ function fileAppender(file, layout, logSize, numBackups, options, timezoneOffset
 
   const app = function (loggingEvent) {
     if (options.removeColor === true) {
+      /* eslint-disable no-control-regex */
       const regex = new RegExp("\x1b[[0-9;]*m", "g");
+      /* eslint-enable no-control-regex */
       for (let i = 0; i < loggingEvent.data.length; i += 1) {
         let d = loggingEvent.data[i];
         d = d.replace(regex, '');

--- a/lib/appenders/file.js
+++ b/lib/appenders/file.js
@@ -54,7 +54,8 @@ function fileAppender(file, layout, logSize, numBackups, options, timezoneOffset
 
   const app = function (loggingEvent) {
     if (options.removeColor === true) {
-      const regex = new RegExp("\x1b[[0-9;]*m", "g"); // eslint-disable-line no-control-regex
+      // eslint-disable-next-line no-control-regex
+      const regex = new RegExp("\x1b[[0-9;]*m", "g");
       for (let i = 0; i < loggingEvent.data.length; i += 1) {
         let d = loggingEvent.data[i];
         d = d.replace(regex, '');

--- a/lib/appenders/file.js
+++ b/lib/appenders/file.js
@@ -56,7 +56,10 @@ function fileAppender(file, layout, logSize, numBackups, options, timezoneOffset
     if (options.removeColor === true) {
       // eslint-disable-next-line no-control-regex
       const regex = /\x1b[[0-9;]*m/g;
-      loggingEvent.data = loggingEvent.data.map(d => d.replace(regex, ''))
+      loggingEvent.data = loggingEvent.data.map(d => {
+        if (typeof d === 'string') return d.replace(regex, '')
+        else return d
+      })
     }
     if (!writer.write(layout(loggingEvent, timezoneOffset) + eol, "utf8")) {
       process.emit('log4js:pause', true);

--- a/lib/appenders/file.js
+++ b/lib/appenders/file.js
@@ -54,9 +54,7 @@ function fileAppender(file, layout, logSize, numBackups, options, timezoneOffset
 
   const app = function (loggingEvent) {
     if (options.removeColor === true) {
-      /* eslint-disable no-control-regex */
-      const regex = new RegExp("\x1b[[0-9;]*m", "g");
-      /* eslint-enable no-control-regex */
+      const regex = new RegExp("\x1b[[0-9;]*m", "g"); // eslint-disable-line no-control-regex
       for (let i = 0; i < loggingEvent.data.length; i += 1) {
         let d = loggingEvent.data[i];
         d = d.replace(regex, '');

--- a/lib/appenders/file.js
+++ b/lib/appenders/file.js
@@ -54,13 +54,12 @@ function fileAppender(file, layout, logSize, numBackups, options, timezoneOffset
 
   const app = function (loggingEvent) {
     if (options.removeColor === true) {
-      let data = loggingEvent.data
-      for (let i = 0; i < data.length; i++) {
-        let d = data[i]
-        d = d.replace(/\x1b\[[0-9]{1,2}m/g, '')
-        data[i] = d
+      const regex = new RegExp("\x1b[[0-9;]*m", "g");
+      for (let i = 0; i < loggingEvent.data.length; i += 1) {
+        let d = loggingEvent.data[i];
+        d = d.replace(regex, '');
+        loggingEvent.data[i] = d;
       }
-      loggingEvent.data = data
     }
     if (!writer.write(layout(loggingEvent, timezoneOffset) + eol, "utf8")) {
       process.emit('log4js:pause', true);

--- a/test/tap/fileAppender-test.js
+++ b/test/tap/fileAppender-test.js
@@ -350,12 +350,13 @@ test("log4js fileAppender", batch => {
     log4js.configure({
       appenders: { 
         plainFile: { type: "file", filename: testFilePlain, removeColor: true },
-        asIsFile: { type: "file", filename: testFilePlain, removeColor: false }
+        asIsFile: { type: "file", filename: testFileAsIs, removeColor: false }
       },
       categories: { default: { appenders: ["plainFile", "asIsFile"], level: "debug" } }
     });
 
-    logger.info("This should be in the file. \x1b[33mColor\x1b[0m \x1b[93;41mshould\x1b[0m be \x1b[38;5;8mplain\x1b[0m.");
+    logger.info("This should be in the file.", 
+                "\x1b[33mColor\x1b[0m \x1b[93;41mshould\x1b[0m be \x1b[38;5;8mplain\x1b[0m.");
 
     await sleep(100);
     let fileContents = await fs.readFile(testFilePlain, "utf8");
@@ -366,7 +367,8 @@ test("log4js fileAppender", batch => {
     );
     
     fileContents = await fs.readFile(testFileAsIs, "utf8");
-    t.include(fileContents, `This should be in the file. \x1b[33mColor\x1b[0m \x1b[93;41mshould\x1b[0m be \x1b[38;5;8mplain\x1b[0m.${EOL}`);
+    t.include(fileContents, "This should be in the file.",
+                            `\x1b[33mColor\x1b[0m \x1b[93;41mshould\x1b[0m be \x1b[38;5;8mplain\x1b[0m.${EOL}`);
     t.match(
       fileContents,
       /\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}] \[INFO] default-settings - /

--- a/test/tap/fileAppender-test.js
+++ b/test/tap/fileAppender-test.js
@@ -356,7 +356,7 @@ test("log4js fileAppender", batch => {
     });
 
     logger.info("This should be in the file.", 
-                "\x1b[33mColor\x1b[0m \x1b[93;41mshould\x1b[0m be \x1b[38;5;8mplain\x1b[0m.");
+      "\x1b[33mColor\x1b[0m \x1b[93;41mshould\x1b[0m be \x1b[38;5;8mplain\x1b[0m.");
 
     await sleep(100);
     let fileContents = await fs.readFile(testFilePlain, "utf8");
@@ -368,7 +368,7 @@ test("log4js fileAppender", batch => {
     
     fileContents = await fs.readFile(testFileAsIs, "utf8");
     t.include(fileContents, "This should be in the file.",
-                            `\x1b[33mColor\x1b[0m \x1b[93;41mshould\x1b[0m be \x1b[38;5;8mplain\x1b[0m.${EOL}`);
+      `\x1b[33mColor\x1b[0m \x1b[93;41mshould\x1b[0m be \x1b[38;5;8mplain\x1b[0m.${EOL}`);
     t.match(
       fileContents,
       /\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}] \[INFO] default-settings - /


### PR DESCRIPTION
It's quite common for developers to use embedded color sequence like `\x1b[33m` in the log string to make the output look beautiful. 

However, if the output is also set to append to some file, the embedded color sequence will write to the given file as is, which may not be expected in some cases. 

Thus I added one more option for file appender, which is `removeColor`. It's a boolean value that controls whether if the appender should detect and remove embedded color sequence before writing to file.

When this option is set to `false`, everything will be written to file as is. For example,

```javascript
log4js.configure({
    appenders: {
        Core: { type: "file", filename: "app.log", removeColor: false },
        console: { type: "console" }
    },
    categories: {
        bot: { appenders: ["console", "Core"], level: "trace" },
        default: { appenders: ["console"], level: "trace" }
    }
})
const botLogger = log4js.getLogger("bot")
botLogger.debug("\x1b[33mHello\x1b[0m")
```

In the `app.log`, it will be `[33mHello[0m`, `\x1b` is invisible.

When this option is set to `true`, then embedded color sequence will be removed before writing to file.

```javascript
log4js.configure({
    appenders: {
        Core: { type: "file", filename: "app.log", removeColor: true },
        console: { type: "console" }
    },
    categories: {
        bot: { appenders: ["console", "Core"], level: "trace" },
        default: { appenders: ["console"], level: "trace" }
    }
})
const botLogger = log4js.getLogger("bot")
botLogger.debug("\x1b[33mHello\x1b[0m")
```

Now in the `app.log`, it will be `Hello` only.

Signed-off-by: Cocoa <0xbbc@0xbbc.com>