### PR TITLE
Donot create appender if not used

### DIFF
--- a/lib/appenders/index.js
+++ b/lib/appenders/index.js
@@ -99,7 +99,7 @@ const setup = (config) => {
   });
 };
 
-setup({ appenders: { out: { type: 'stdout' } }, categories: { default: { appenders: ["out"], level: "trace" } } });
+setup({ appenders: { out: { type: 'stdout' } }, categories: { default: { appenders: ['out'], level: 'trace' } } });
 
 configuration.addListener((config) => {
   configuration.throwExceptionIf(

--- a/lib/appenders/index.js
+++ b/lib/appenders/index.js
@@ -82,18 +82,24 @@ const createAppender = (name, config) => {
       appender => getAppender(appender, config),
       levels
     );
-  }, () => {});
+  }, () => { });
 };
 
 const setup = (config) => {
   appenders.clear();
   appendersLoading.clear();
+  const usedAppenders = [];
+  Object.values(config.categories).forEach(category => {
+    usedAppenders.push(...category.appenders)
+  });
   Object.keys(config.appenders).forEach((name) => {
-    getAppender(name, config);
+    if (usedAppenders.includes(name)) {
+      getAppender(name, config);
+    }
   });
 };
 
-setup({ appenders: { out: { type: 'stdout' } } });
+setup({ appenders: { out: { type: 'stdout' } }, categories: { default: { appenders: ["out"], level: "trace" } } });
 
 configuration.addListener((config) => {
   configuration.throwExceptionIf(

--- a/test/tap/configuration-validation-test.js
+++ b/test/tap/configuration-validation-test.js
@@ -410,5 +410,26 @@ test("log4js configuration validation", batch => {
     }
   );
 
+  batch.test("should not create appender instance if not used in categories", t => {
+    const used = {};
+    const notUsed = {};
+    const sandboxedLog4js = sandbox.require("../../lib/log4js", {
+      requires: {
+        cat: testAppender("meow", used),
+        dog: testAppender("woof", notUsed)
+      },
+      ignoreMissing: true
+    });
+
+    sandboxedLog4js.configure({
+      appenders: { used: { type: "cat" }, notUsed: { type: "dog" } },
+      categories: { default: { appenders: ["used"], level: "ERROR" } }
+    });
+
+    t.ok(used.configureCalled);
+    t.notOk(notUsed.configureCalled);
+    t.end();
+  });
+
   batch.end();
 });


### PR DESCRIPTION
Related to #1000 . The fix will check if an appender exists in a category before trying to create it. 