### PR TITLE
Access to 'category' field of logger objects in TS

### DIFF
--- a/types/log4js.d.ts
+++ b/types/log4js.d.ts
@@ -286,6 +286,7 @@ export interface Configuration {
 export class Logger {
 	new(dispatch: Function, name: string): Logger;
 
+	readonly category: string;
 	level: string;
 
 	log(...args: any[]): void;


### PR DESCRIPTION
Sometimes it can be useful to know the category of the logger.
The category can be read from pure JavaScript code but TypeScript code cannot read it as the field is not declared.

This change adds the field to the TypeScript declaration. The access to it is read-only as changing the category of logger probably makes no sense.