### PR TITLE
fix: fileSync was missing from core appenders

### DIFF
--- a/lib/appenders/index.js
+++ b/lib/appenders/index.js
@@ -16,6 +16,7 @@ coreAppenders.set('categoryFilter', require('./categoryFilter'));
 coreAppenders.set('noLogFilter', require('./noLogFilter'));
 coreAppenders.set('file', require('./file'));
 coreAppenders.set('dateFile', require('./dateFile'));
+coreAppenders.set('fileSync', require('./fileSync'));
 
 const appenders = new Map();
 


### PR DESCRIPTION
Fixes issue #1008 (Problem using webpack with fileSync Appender).

This PR pre-loads the fileSync appender in lib/appenders/index.js so that Webpack can find it.

(This is based off of how issue #816 was fixed with PR #882 .)