### PR TITLE
fix: log4js-node/log4js-node#968

### DIFF
--- a/lib/appenders/index.js
+++ b/lib/appenders/index.js
@@ -6,6 +6,11 @@ const levels = require('../levels');
 const layouts = require('../layouts');
 const adapters = require('./adapters');
 
+const isNode =
+  typeof process !== 'undefined' &&
+  process.versions != null &&
+  process.versions.node != null;
+
 // pre-load the core appenders so that webpack can find them
 const coreAppenders = new Map();
 coreAppenders.set('console', require('./console'));
@@ -14,9 +19,9 @@ coreAppenders.set('stderr', require('./stderr'));
 coreAppenders.set('logLevelFilter', require('./logLevelFilter'));
 coreAppenders.set('categoryFilter', require('./categoryFilter'));
 coreAppenders.set('noLogFilter', require('./noLogFilter'));
-coreAppenders.set('file', require('./file'));
-coreAppenders.set('dateFile', require('./dateFile'));
-coreAppenders.set('fileSync', require('./fileSync'));
+coreAppenders.set('file', isNode ? require('./file') : {});
+coreAppenders.set('dateFile', isNode ? require('./dateFile') : {});
+coreAppenders.set('fileSync', isNode ? require('./fileSync'): {});
 
 const appenders = new Map();
 

--- a/lib/appenders/index.js
+++ b/lib/appenders/index.js
@@ -6,6 +6,7 @@ const levels = require('../levels');
 const layouts = require('../layouts');
 const adapters = require('./adapters');
 
+// Webpack needs some appenders to be screened out.
 const isNode =
   typeof process !== 'undefined' &&
   process.versions != null &&

--- a/lib/clustering.js
+++ b/lib/clustering.js
@@ -2,13 +2,20 @@ const debug = require("debug")("log4js:clustering");
 const LoggingEvent = require("./LoggingEvent");
 const configuration = require("./configuration");
 
-let disabled = false;
+const isNode =
+  typeof process !== 'undefined' &&
+  process.versions != null &&
+  process.versions.node != null;
+
+let disabled = !isNode;
 let cluster = null;
-try {
-  cluster = require("cluster"); //eslint-disable-line
-} catch (e) {
-  debug("cluster module not present");
-  disabled = true;
+if (!disabled) {
+  try {
+    cluster = require("cluster"); //eslint-disable-line
+  } catch (e) {
+    debug("cluster module not present");
+    disabled = true;
+  }
 }
 
 const listeners = [];


### PR DESCRIPTION
This addresses #968 by allowing certain `require`'s to run only in node, not in the browser.

All tests pass as before. However, I didn't add new tests specifically for this, which I
acknowledge isn't great, but I'm not sure how to write tests for "this works when
building with webpack" beyond adding a whole webpack project to the tests, and
grepping output. There might be a great way, but I'm not sure what it is.

I also found it useful to add this in the `package.json` of the project using log4js,
which I'm adding as a note here only in case it is useful for others facing this problem.

```
"browser": {
  "fs": false,
  "cluster": false
},
```
The initial PR build failed on Windows for unknown reasons; hopefully another build attempt will resolve that.