### PR TITLE
Fix TCP appender with Webpack and Typescript

### DIFF
--- a/lib/appenders/index.js
+++ b/lib/appenders/index.js
@@ -17,6 +17,7 @@ coreAppenders.set('noLogFilter', require('./noLogFilter'));
 coreAppenders.set('file', require('./file'));
 coreAppenders.set('dateFile', require('./dateFile'));
 coreAppenders.set('fileSync', require('./fileSync'));
+coreAppenders.set('tcp', require('./tcp'));
 
 const appenders = new Map();
 

--- a/types/log4js.d.ts
+++ b/types/log4js.d.ts
@@ -236,6 +236,23 @@ export interface StandardOutputAppender {
   layout?: Layout;
 }
 
+/**
+ * TCP Appender
+ *
+ * @see https://log4js-node.github.io/log4js-node/tcp.html
+ */
+export interface TCPAppender {
+  type: 'tcp';
+  // defaults to 5000
+  port?: number
+  // defaults to localhost
+  host?: string
+  // default to __LOG4JS__
+  endMsg?: string
+  // defaults to a serialized log event
+  layout?: Layout;
+}
+
 export interface CustomAppender {
   type: string | AppenderModule;
   [key: string]: any;
@@ -257,6 +274,7 @@ export type Appender = CategoryFilterAppender
   | RecordingAppender
   | StandardErrorAppender
   | StandardOutputAppender
+  | TCPAppender
   | CustomAppender;
 
 export interface Levels {


### PR DESCRIPTION
This is much like the fix for #1008 and #816 
I've also included typescript typings for the TCP appender. I can remove these if you prefer.

There are some other core appenders that are also not in this list, however I'm unsure if this was intentional or by accident so have only included the one I'm currently concerned with and tested for now.