### PR TITLE
fix: file appender types

### DIFF
--- a/types/log4js.d.ts
+++ b/types/log4js.d.ts
@@ -132,7 +132,7 @@ export interface FileAppender {
   backups?: number;
   // defaults to basic layout
   layout?: Layout;
-  numBackups?: number;
+  backups?: number;
   compress?: boolean; // compress the backups
   // keep the file extension when rotating logs
   keepFileExt?: boolean;

--- a/types/log4js.d.ts
+++ b/types/log4js.d.ts
@@ -132,7 +132,6 @@ export interface FileAppender {
   backups?: number;
   // defaults to basic layout
   layout?: Layout;
-  backups?: number;
   compress?: boolean; // compress the backups
   // keep the file extension when rotating logs
   keepFileExt?: boolean;


### PR DESCRIPTION
The Typescript types are wrong for the File appender. This is related to https://github.com/log4js-node/log4js-node/pull/807