### PR TITLE
feat: add evaluateArgsThatAreFunctions option

### DIFF
--- a/lib/categories.js
+++ b/lib/categories.js
@@ -140,6 +140,7 @@ configuration.addListener((config) => {
 });
 
 const setup = (config) => {
+  const { evaluateArgsThatAreFunctions: globalEvaluateArgsThatAreFunctions = false } = config;
   categories.clear();
 
   const categoryNames = Object.keys(config.categories);
@@ -149,12 +150,17 @@ const setup = (config) => {
     category.appenders.forEach((appender) => {
       categoryAppenders.push(appenders.get(appender));
       debug(`Creating category ${name}`);
+      const {
+        level, enableCallStack = false,
+        evaluateArgsThatAreFunctions = globalEvaluateArgsThatAreFunctions
+      } = category;
       categories.set(
         name,
         {
           appenders: categoryAppenders,
-          level: levels.getLevel(category.level),
-          enableCallStack: category.enableCallStack || false
+          level: levels.getLevel(level),
+          enableCallStack,
+          evaluateArgsThatAreFunctions
         }
       );
     });
@@ -199,10 +205,19 @@ const setEnableCallStackForCategory = (category, useCallStack) => {
   configForCategory(category).enableCallStack = useCallStack;
 };
 
+const getEvaluateArgsThatAreFunctionsForCategory = (category) => {
+  return configForCategory(category).evaluateArgsThatAreFunctions === true;
+};
+const setEvaluateArgsThatAreFunctionsForCategory = (category, evaluateArgsThatAreFunctions) => {
+  configForCategory(category).evaluateArgsThatAreFunctions = evaluateArgsThatAreFunctions;
+};
+
 module.exports = {
   appendersForCategory,
   getLevelForCategory,
   setLevelForCategory,
   getEnableCallStackForCategory,
   setEnableCallStackForCategory,
+  getEvaluateArgsThatAreFunctionsForCategory,
+  setEvaluateArgsThatAreFunctionsForCategory
 };

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -67,6 +67,14 @@ class Logger {
     categories.setEnableCallStackForCategory(this.category, bool === true);
   }
 
+  get evaluateArgsThatAreFunctions() {
+    return categories.getEvaluateArgsThatAreFunctionsForCategory(this.category);
+  }
+
+  set evaluateArgsThatAreFunctions(bool) {
+    categories.setEvaluateArgsThatAreFunctionsForCategory(this.category, bool === true);
+  }
+
   log(level, ...args) {
     const logLevel = levels.getLevel(level, levels.INFO);
     if (this.isLevelEnabled(logLevel)) {
@@ -80,6 +88,9 @@ class Logger {
 
   _log(level, data) {
     debug(`sending log data (${level}) to appenders`);
+    if (this.evaluateArgsThatAreFunctions) {
+      data = data.map((e) => typeof e === 'function' ? e() : e);
+    }
     const loggingEvent = new LoggingEvent(
       this.category,
       level,

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "scripts": {
     "pretest": "eslint \"lib/**/*.js\" \"test/**/*.js\"",
     "test": "tap \"test/tap/**/*.js\" --cov",
+    "test:only": "tap \"test/tap/fileAppender-test.js\"",
     "typings": "tsc -p types/tsconfig.json",
     "codecov": "tap \"test/tap/**/*.js\" --cov --coverage-report=lcov && codecov"
   },


### PR DESCRIPTION
This is meant to achieve the same functionality as https://github.com/log4js-node/log4js-node/pull/424

I tried adding the config parameter as discussed in #424, and I figured we might as well make it possible to define it for each category.

I did this the same way as what is currently done for the `useCallStack` option.

I ended up implementing this in a different place than in #424:  right in the logger, instead of in the layout. 

Before I start writing tests, can you confirm: 
- that this feature is still something you find interesting ?
- that this implementation is ok for you ?

In a way, I think it would actually make more sense to implement this in the layouts or the appenders, rather than in the categories, but for my use cases, a category based control works fine, and I don't really have the courage to get into the layouts / appenders code right now.  