### PR TITLE
fix: %f{depth} filename separator

### DIFF
--- a/lib/layouts.js
+++ b/lib/layouts.js
@@ -1,7 +1,6 @@
 const dateFormat = require('date-format');
 const os = require('os');
 const util = require('util');
-const path = require('path');
 
 const styles = {
   // styles
@@ -223,9 +222,10 @@ function patternLayout(pattern, tokens) {
     let filename = loggingEvent.fileName || '';
     if (specifier) {
       const fileDepth = parseInt(specifier, 10);
-      const fileList = filename.split(path.sep);
+      const fileList = filename.split(/\/|\\/);
+      const fileListWithSeparator = filename.split(/(\/|\\)/);
       if (fileList.length > fileDepth) {
-        filename = fileList.slice(-fileDepth).join(path.sep);
+        filename = fileListWithSeparator.slice(-fileDepth * 2 + 1).join('');
       }
     }
 


### PR DESCRIPTION
Changed the split parameter to capture both `\` and `/` separators inside array, and then modified the join expression to account for the extra elements in the array. Also removed path import as it's not longer needed.

Related to #1060 