### PR TITLE
fix(logger.log): warn on invalid log-level

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -7,6 +7,7 @@ const categories = require("./categories");
 const configuration = require("./configuration");
 
 const stackReg = /at (?:(.+)\s+\()?(?:(.+?):(\d+)(?::(\d+))?|([^)]+))\)?/;
+
 function defaultParseCallStack(data, skipIdx = 4) {
   const stacklines = data.stack.split("\n").slice(skipIdx);
   const lineMatch = stackReg.exec(stacklines[0]);
@@ -68,7 +69,11 @@ class Logger {
   }
 
   log(level, ...args) {
-    const logLevel = levels.getLevel(level, levels.INFO);
+    let logLevel = levels.getLevel(level);
+    if (!logLevel) {
+      this._log(levels.WARN, 'log4js:logger.log: invalid value for log-level as first parameter given: ', level);
+      logLevel = levels.INFO;
+    }
     if (this.isLevelEnabled(logLevel)) {
       this._log(logLevel, args);
     }
@@ -116,11 +121,11 @@ function addLevelMethods(target) {
   );
   const isLevelMethod = levelMethod[0].toUpperCase() + levelMethod.slice(1);
 
-  Logger.prototype[`is${isLevelMethod}Enabled`] = function() {
+  Logger.prototype[`is${isLevelMethod}Enabled`] = function () {
     return this.isLevelEnabled(level);
   };
 
-  Logger.prototype[levelMethod] = function(...args) {
+  Logger.prototype[levelMethod] = function (...args) {
     this.log(level, ...args);
   };
 }

--- a/test/tap/newLevel-test.js
+++ b/test/tap/newLevel-test.js
@@ -237,8 +237,10 @@ test("../../lib/logger", batch => {
     logger.log(log4js.levels.getLevel("LEVEL_DOES_NEXT_EXIST"), "Event 2");
 
     const events = recording.replay();
-    t.equal(events[0].level.toString(), "INFO", "should fall back to INFO");
+    t.equal(events[0].level.toString(), "WARN", "should log warning");
     t.equal(events[1].level.toString(), "INFO", "should fall back to INFO");
+    t.equal(events[2].level.toString(), "WARN", "should log warning");
+    t.equal(events[3].level.toString(), "INFO", "should fall back to INFO");
     t.end();
   });
 


### PR DESCRIPTION
a warning is logged if the `log` method is used with an unknown log-level
this happens whenever people confuse the `log` method with yet another log-level-short method (like in the browser console.log)
adjusted `newLevel-test` accordingly

rel: https://github.com/log4js-node/log4js-node/issues/1042

Signed-off-by: abernh <a.bernhard@23go.de>