### PR TITLE
Avoid creating multiple SIGHUP listeners for File Appender

### DIFF
--- a/lib/appenders/file.js
+++ b/lib/appenders/file.js
@@ -5,6 +5,14 @@ const os = require('os');
 
 const eol = os.EOL;
 
+let mainSighupListenerStarted = false;
+const sighupListeners = new Set();
+function mainSighupHandler() {
+  sighupListeners.forEach((app) => {
+    app.sighupHandler();
+  });
+}
+
 function openTheStream(file, fileSize, numFiles, options) {
   const stream = new streams.RollingFileStream(
     file,
@@ -76,14 +84,22 @@ function fileAppender(file, layout, logSize, numBackups, options, timezoneOffset
   };
 
   app.shutdown = function (complete) {
-    process.removeListener('SIGHUP', app.sighupHandler);
+    sighupListeners.delete(app);
+    if (sighupListeners.size === 0 && mainSighupListenerStarted) {
+      process.removeListener('SIGHUP', mainSighupHandler);
+      mainSighupListenerStarted = false;
+    }
     writer.end('', 'utf-8', complete);
   };
 
   // On SIGHUP, close and reopen all files. This allows this appender to work with
   // logrotate. Note that if you are using logrotate, you should not set
   // `logSize`.
-  process.on('SIGHUP', app.sighupHandler);
+  sighupListeners.add(app);
+  if (!mainSighupListenerStarted) {
+    process.on('SIGHUP', mainSighupHandler);
+    mainSighupListenerStarted = true;
+  }
 
   return app;
 }


### PR DESCRIPTION
Fixes #437, Fixes #556, Fixes #700, Fixes #785, Fixes #852, Fixes #886

> _Originally posted by @nomiddlename in https://github.com/log4js-node/log4js-node/issues/852#issuecomment-496316399_
> I think the issue is that each file appender instance adds a SIGHUP handler, when they could all use the same handler. I'll see if I can work on a fix.

Implemented a fix based on @nomiddlename's comment, to create a single SIGHUP listener.