### PR TITLE
Fixes file descriptor leak in certain use cases

### DIFF
--- a/lib/appenders/index.js
+++ b/lib/appenders/index.js
@@ -102,7 +102,10 @@ const setup = (config) => {
   });
 };
 
-setup({ appenders: { out: { type: 'stdout' } }, categories: { default: { appenders: ['out'], level: 'trace' } } });
+const init = () => {
+  setup({ appenders: { out: { type: 'stdout' } }, categories: { default: { appenders: ['out'], level: 'trace' } } });
+};
+init();
 
 configuration.addListener((config) => {
   configuration.throwExceptionIf(
@@ -129,3 +132,4 @@ configuration.addListener((config) => {
 configuration.addListener(setup);
 
 module.exports = appenders;
+module.exports.init = init;

--- a/lib/categories.js
+++ b/lib/categories.js
@@ -203,11 +203,12 @@ const setEnableCallStackForCategory = (category, useCallStack) => {
   configForCategory(category).enableCallStack = useCallStack;
 };
 
-module.exports = {
+module.exports = categories;
+module.exports = Object.assign(module.exports, {
   appendersForCategory,
   getLevelForCategory,
   setLevelForCategory,
   getEnableCallStackForCategory,
   setEnableCallStackForCategory,
   init,
-};
+});

--- a/lib/categories.js
+++ b/lib/categories.js
@@ -161,7 +161,11 @@ const setup = (config) => {
   });
 };
 
-setup({ categories: { default: { appenders: ['out'], level: 'OFF' } } });
+const init = () => {
+  setup({ categories: { default: { appenders: ['out'], level: 'OFF' } } });
+};
+init();
+
 configuration.addListener(setup);
 
 const configForCategory = (category) => {
@@ -205,4 +209,5 @@ module.exports = {
   setLevelForCategory,
   getEnableCallStackForCategory,
   setEnableCallStackForCategory,
+  init,
 };

--- a/lib/log4js.js
+++ b/lib/log4js.js
@@ -56,6 +56,11 @@ function loadConfigurationFile(filename) {
 }
 
 function configure(configurationFileOrObject) {
+  if (enabled) {
+    // eslint-disable-next-line no-use-before-define
+    shutdown();
+  }
+
   let configObject = configurationFileOrObject;
 
   if (typeof configObject === "string") {
@@ -87,8 +92,14 @@ function shutdown(cb) {
   // not being able to be drained because of run-away log writes.
   enabled = false;
 
-  // Call each of the shutdown functions in parallel
+  // Clone out to maintain a reference
   const appendersToCheck = Array.from(appenders.values());
+
+  // Reset immediately to prevent leaks
+  appenders.init();
+  categories.init();
+
+  // Call each of the shutdown functions in parallel
   const shutdownFunctions = appendersToCheck.reduceRight(
     (accum, next) => (next.shutdown ? accum + 1 : accum),
     0

--- a/lib/log4js.js
+++ b/lib/log4js.js
@@ -104,9 +104,13 @@ function shutdown(cb) {
     (accum, next) => (next.shutdown ? accum + 1 : accum),
     0
   );
+  if (shutdownFunctions === 0) {
+    debug("No appenders with shutdown functions found.");
+    return cb !== undefined && cb();
+  }
+
   let completed = 0;
   let error;
-
   debug(`Found ${shutdownFunctions} appenders with shutdown functions.`);
   function complete(err) {
     error = error || err;
@@ -119,12 +123,6 @@ function shutdown(cb) {
       }
     }
   }
-
-  if (shutdownFunctions === 0) {
-    debug("No appenders with shutdown functions found.");
-    return cb !== undefined && cb();
-  }
-
   appendersToCheck.filter(a => a.shutdown).forEach(a => a.shutdown(complete));
 
   return null;

--- a/test/tap/file-descriptor-leak-test.js
+++ b/test/tap/file-descriptor-leak-test.js
@@ -1,0 +1,84 @@
+const { test } = require("tap");
+const fs = require("fs");
+const path = require("path");
+const log4js = require("../../lib/log4js");
+
+const removeFiles = async filenames => {
+  if (!Array.isArray(filenames))
+    filenames = [filenames];
+  const promises = filenames.map(filename => {
+    return fs.promises.unlink(filename);
+  });
+  await Promise.allSettled(promises);
+};
+
+// no file descriptors on Windows, so don't run the tests
+if (process.platform !== "win32") {
+
+  test("multiple log4js configure fd leak test", batch => {
+    const config = {
+      appenders: {},
+      categories: {
+        default: { appenders: [], level: 'debug' }
+      }
+    };
+
+    // create 11 appenders
+    const numOfAppenders = 11;
+    for (let i = 1; i <= numOfAppenders; i++) {
+      config.appenders[`app${i}`] = { type: 'file', filename: path.join(__dirname, `file${i}.log`) };
+      config.categories.default.appenders.push(`app${i}`);
+    }
+
+    const initialFd = fs.readdirSync('/proc/self/fd').length;
+    let loadedFd;
+
+    batch.test("initial log4js configure to increase file descriptor count", t => {
+      log4js.configure(config);
+
+      // wait for the file system to catch up
+      setTimeout(() => {
+        loadedFd = fs.readdirSync('/proc/self/fd').length;
+        t.equal(loadedFd, initialFd + numOfAppenders, 
+          `file descriptor count should increase by ${numOfAppenders} after 1st configure() call`);
+        t.end();
+      }, 1000);
+    });
+
+    batch.test("repeated log4js configure to not increase file descriptor count", t => {
+      log4js.configure(config);
+      log4js.configure(config);
+      log4js.configure(config);
+
+      // wait for the file system to catch up
+      setTimeout(() => {
+        t.equal(fs.readdirSync('/proc/self/fd').length, loadedFd, 
+          `file descriptor count should be identical after repeated configure() calls`);
+        t.end();
+      }, 1000);
+    });
+
+    batch.test("file descriptor count should return back to initial count", t => {
+      log4js.shutdown();
+
+      // wait for the file system to catch up
+      setTimeout(() => {
+        t.equal(fs.readdirSync('/proc/self/fd').length, initialFd, 
+          `file descriptor count should be back to initial`);
+        t.end();
+      }, 1000);
+    });
+
+    batch.teardown(async () => {
+      log4js.shutdown();
+
+      const filenames = Object.values(config.appenders).map(appender => {
+        return appender.filename;
+      });
+      await removeFiles(filenames);
+    });
+
+    batch.end();
+  });
+
+}

--- a/test/tap/file-descriptor-leak-test.js
+++ b/test/tap/file-descriptor-leak-test.js
@@ -6,9 +6,7 @@ const log4js = require("../../lib/log4js");
 const removeFiles = async filenames => {
   if (!Array.isArray(filenames))
     filenames = [filenames];
-  const promises = filenames.map(filename => {
-    return fs.promises.unlink(filename);
-  });
+  const promises = filenames.map(filename => fs.promises.unlink(filename));
   await Promise.allSettled(promises);
 };
 
@@ -72,9 +70,7 @@ if (process.platform !== "win32") {
     batch.teardown(async () => {
       log4js.shutdown();
 
-      const filenames = Object.values(config.appenders).map(appender => {
-        return appender.filename;
-      });
+      const filenames = Object.values(config.appenders).map(appender => appender.filename);
       await removeFiles(filenames);
     });
 

--- a/test/tap/file-descriptor-leak-test.js
+++ b/test/tap/file-descriptor-leak-test.js
@@ -40,7 +40,7 @@ if (process.platform !== "win32") {
         t.equal(loadedFd, initialFd + numOfAppenders, 
           `file descriptor count should increase by ${numOfAppenders} after 1st configure() call`);
         t.end();
-      }, 1000);
+      }, 250);
     });
 
     batch.test("repeated log4js configure to not increase file descriptor count", t => {
@@ -53,7 +53,7 @@ if (process.platform !== "win32") {
         t.equal(fs.readdirSync('/proc/self/fd').length, loadedFd, 
           `file descriptor count should be identical after repeated configure() calls`);
         t.end();
-      }, 1000);
+      }, 250);
     });
 
     batch.test("file descriptor count should return back to initial count", t => {
@@ -64,7 +64,7 @@ if (process.platform !== "win32") {
         t.equal(fs.readdirSync('/proc/self/fd').length, initialFd, 
           `file descriptor count should be back to initial`);
         t.end();
-      }, 1000);
+      }, 250);
     });
 
     batch.teardown(async () => {

--- a/test/tap/logging-test.js
+++ b/test/tap/logging-test.js
@@ -4,6 +4,52 @@ const util = require("util");
 const recording = require("../../lib/appenders/recording");
 
 test("log4js", batch => {
+  batch.test("shutdown should return appenders and categories back to initial state", t => {
+    const stringifyMap = (map) => JSON.stringify(Array.from(map));
+    const deepCopyMap = (map) => new Map(JSON.parse(stringifyMap(map)));
+
+    const log4js = require("../../lib/log4js");
+
+    const appenders = require("../../lib/appenders");
+    const categories = require("../../lib/categories");
+    const initialAppenders = deepCopyMap(appenders);
+    const initialCategories = deepCopyMap(categories);
+
+    log4js.configure({
+      appenders: { recorder: { type: "recording" } },
+      categories: { default: { appenders: ["recorder"], level: "DEBUG" } }
+    });
+
+    const configuredAppenders = deepCopyMap(appenders);
+    const configuredCategories = deepCopyMap(categories);
+    t.notEqual(
+      stringifyMap(configuredAppenders), 
+      stringifyMap(initialAppenders), 
+      "appenders should be different from initial state"
+    );
+    t.notEqual(
+      stringifyMap(configuredCategories), 
+      stringifyMap(initialCategories), 
+      "categories should be different from initial state"
+    );
+
+    log4js.shutdown(() => {
+      const finalAppenders = deepCopyMap(appenders);
+      const finalCategories = deepCopyMap(categories);
+      t.equal(
+        stringifyMap(finalAppenders),
+        stringifyMap(initialAppenders), 
+        "appenders should revert back to initial state"
+      );
+      t.equal(
+        stringifyMap(finalCategories), 
+        stringifyMap(initialCategories), 
+        "categories should revert back to initial state"
+      );
+      t.end();
+    });
+  });
+
   batch.test("getLogger", t => {
     const log4js = require("../../lib/log4js");
     log4js.configure({


### PR DESCRIPTION
Fixes #788, Fixes #978, Fixes #1005, Fixes #1058
Additionally, this PR supersedes PR #1083

**Allow multiple configure() calls:**
Calling multiple `configure()` without `shutdown()` may leave resources open (file handles, network connections, etc).
This patch explicitly does a `shutdown() `for subsequently `configure()` to prevent resource leaks.

**Allow multiple shutdown() calls:**
Within the `shutdown()`, it now clears `appenders` and `categories`. Repeated/duplicated `shutdown()` calls will no longer traverse the same `appenders` to shut them down them again which will result in `Error [ERR_STREAM_WRITE_AFTER_END]: write after end`.