### PR TITLE
test: update fakeFS.read as graceful-fs uses it

### DIFF
--- a/test/tap/configuration-test.js
+++ b/test/tap/configuration-test.js
@@ -17,6 +17,7 @@ test("log4js configure", batch => {
       realpath: () => {}, // fs-extra looks for this
       ReadStream: realFS.ReadStream, // need to define these, because graceful-fs uses them
       WriteStream: realFS.WriteStream,
+      read: realFS.read,
       closeSync: () => {},
       config: {
         appenders: {


### PR DESCRIPTION
`graceful-fs@4.2.5` broke it as it changed to use `Object.setPrototypeOf(read, fs$read)`.

```diff
-L136    read.__proto__ = fs$read
+L136    if (Object.setPrototypeOf) Object.setPrototypeOf(read, fs$read)
```
_(https://github.com/isaacs/node-graceful-fs/commit/c55c1b8cb32510f92bd33d7c833364ecd3964dea#diff-f740ecac46b2fdaa68156b133262813aa6f66218b11d8709bab83580e76e486dR136)_

When `fakeFS.read` is `undefined`, it now throws an error as `Object.setPrototypeOf` doesn't accept `undefined` in its parameters.