### PR TITLE
test: update fakeFS.read as graceful-fs uses it

### DIFF
--- a/test/tap/configuration-test.js
+++ b/test/tap/configuration-test.js
@@ -14,7 +14,7 @@ test("log4js configure", batch => {
     fileRead = 0;
 
     fakeFS = {
-      realpath: () => {}, // fs-extra looks for this
+      realpath: realFS.realpath, // fs-extra looks for this
       ReadStream: realFS.ReadStream, // need to define these, because graceful-fs uses them
       WriteStream: realFS.WriteStream,
       read: realFS.read,


### PR DESCRIPTION
`fs-extra@10.0.0` broke it as it removed the check for `fs.realpath.native`.

```diff
+L064 exports.realpath.native = u(fs.realpath.native)

-L126
-L127 // fs.realpath.native only available in Node v9.2+
-L128 if (typeof fs.realpath.native === 'function') {
-L129   exports.realpath.native = u(fs.realpath.native)
-L130 }
```
_(https://github.com/jprichardson/node-fs-extra/pull/887/files)_

When `fs.realpath` is an empty function, fs.realpath.native is `undefined`.

https://github.com/log4js-node/log4js-node/blob/25c17ad9802082d7a0fcf9c228cc5b99661e3ed9/test/tap/configuration-test.js#L17