### PR TITLE
Make typings match code better

### DIFF
--- a/types/log4js.d.ts
+++ b/types/log4js.d.ts
@@ -263,13 +263,8 @@ export interface CustomAppender {
 }
 
 export interface AppenderModule {
-  configure: (config: Config, layouts: LayoutsParam) => AppenderGenerator;
+  configure: (config: Config, layouts: LayoutsParam) => AppenderFunction;
 }
-
-export type AppenderGenerator = (
-  layout: LayoutFunction,
-  timezoneOffset?: string
-) => AppenderFunction;
 
 export type AppenderFunction = (loggingEvent: LoggingEvent) => void;
 
@@ -321,7 +316,7 @@ export interface Levels {
   FATAL: Level;
   OFF: Level;
   levels: Level[];
-  getLevel(level: Level | string, defaultLevel: Level): Level;
+  getLevel(level: Level | string, defaultLevel?: Level): Level;
   addLevels(customLevels: object): void;
 }
 

--- a/types/test.ts
+++ b/types/test.ts
@@ -133,7 +133,7 @@ log4js.connectLogger(logger2, {
 
 //support for passing in an appender module
 log4js.configure({
-  appenders: { thing: { type: { configure: () => {} }}},
+  appenders: { thing: { type: { configure: () => () => {} }}},
   categories: { default: { appenders: ['thing'], level: 'debug'}}
 });
 


### PR DESCRIPTION
Fixes v6.4.0 regressions.

There is an npm script `npm run typings` which actually failed before
this commit. This seems to have been a combination of incorrect typings
(a mandatory argument to `getLevel` that should be optional, the idea
that for custom appenders `configure` should return an intermediate
"generator" function before the appender function itself) as well as
mistakes in the test file (which had an appender module which had one
level of function nesting too few).

Specifically, for the `configure` function on appenders, I believe there
should be two levels of function: an outer function taking one-time
configuration, and an inner function taking an individual log messages.
The typings file wanted there to be three layers, and the test file
wanted there to be one layer.

Fixes #1155.