### PR TITLE
Add types check to publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -17,6 +17,7 @@ jobs:
           node-version: 16
       - run: npm ci
       - run: npm test
+      - run: npm run typings
 
   publish-npm:
     needs: build


### PR DESCRIPTION
To avoid accidentally publishing broken typescript definitions to NPM in future.