### PR TITLE
refactor date pattern names for clarity (when %date actually means %datetime)

### DIFF
--- a/docs/layouts.md
+++ b/docs/layouts.md
@@ -116,7 +116,7 @@ Fields can be any of:
 *  `%c` log category
 *  `%h` hostname
 *  `%m` log data
-*  `%d` date, formatted - default is `ISO8601`, format options are: `ISO8601`, `ISO8601_WITH_TZ_OFFSET`, `ABSOLUTE`, `DATE`, or any string compatible with the [date-format](https://www.npmjs.com/package/date-format) library. e.g. `%d{DATE}`, `%d{yyyy/MM/dd-hh.mm.ss}`
+*  `%d` date, formatted - default is `ISO8601`, format options are: `ISO8601`, `ISO8601_WITH_TZ_OFFSET`, `ABSOLUTETIME`, `DATETIME`, or any string compatible with the [date-format](https://www.npmjs.com/package/date-format) library. e.g. `%d{DATETIME}`, `%d{yyyy/MM/dd-hh.mm.ss}`
 *  `%%` % - for when you want a literal `%` in your output
 *  `%n` newline
 *  `%z` process id (from `process.pid`)

--- a/lib/layouts.js
+++ b/lib/layouts.js
@@ -2,6 +2,7 @@ const dateFormat = require('date-format');
 const os = require('os');
 const util = require('util');
 const path = require('path');
+const debug = require('debug')('log4js:layouts');
 
 const styles = {
   // styles
@@ -144,14 +145,27 @@ function patternLayout(pattern, tokens) {
     if (specifier) {
       format = specifier;
       // Pick up special cases
-      if (format === 'ISO8601') {
-        format = dateFormat.ISO8601_FORMAT;
-      } else if (format === 'ISO8601_WITH_TZ_OFFSET') {
-        format = dateFormat.ISO8601_WITH_TZ_OFFSET_FORMAT;
-      } else if (format === 'ABSOLUTE') {
-        format = dateFormat.ABSOLUTETIME_FORMAT;
-      } else if (format === 'DATE') {
-        format = dateFormat.DATETIME_FORMAT;
+      switch (format) {
+        case 'ISO8601':
+        case 'ISO8601_FORMAT':
+          format = dateFormat.ISO8601_FORMAT;
+          break;
+        case 'ISO8601_WITH_TZ_OFFSET':
+        case 'ISO8601_WITH_TZ_OFFSET_FORMAT':
+          format = dateFormat.ISO8601_WITH_TZ_OFFSET_FORMAT;
+          break;
+        case 'ABSOLUTE':
+          debug("DEPRECATION: Pattern %d{ABSOLUTE} is deprecated and replaced by %d{ABSOLUTETIME}.");
+        case 'ABSOLUTETIME':
+        case 'ABSOLUTETIME_FORMAT':
+          format = dateFormat.ABSOLUTETIME_FORMAT;
+          break;
+        case 'DATE':
+          debug("DEPRECATION: Pattern %d{DATE} is deprecated and replaced by %d{DATETIME}.");
+        case 'DATETIME':
+        case 'DATETIME_FORMAT':
+          format = dateFormat.DATETIME_FORMAT;
+          break;
       }
     }
     // Format the date

--- a/lib/layouts.js
+++ b/lib/layouts.js
@@ -156,16 +156,19 @@ function patternLayout(pattern, tokens) {
           break;
         case 'ABSOLUTE':
           debug("DEPRECATION: Pattern %d{ABSOLUTE} is deprecated and replaced by %d{ABSOLUTETIME}.");
+          // falls through
         case 'ABSOLUTETIME':
         case 'ABSOLUTETIME_FORMAT':
           format = dateFormat.ABSOLUTETIME_FORMAT;
           break;
         case 'DATE':
           debug("DEPRECATION: Pattern %d{DATE} is deprecated and replaced by %d{DATETIME}.");
+          // falls through
         case 'DATETIME':
         case 'DATETIME_FORMAT':
           format = dateFormat.DATETIME_FORMAT;
           break;
+        // no default
       }
     }
     // Format the date

--- a/test/tap/layouts-test.js
+++ b/test/tap/layouts-test.js
@@ -412,23 +412,21 @@ test("log4js layouts", batch => {
         "2010-12-05T14:18:30.045"
       );
 
-      // Commenting this test out, because it does not work in travis
-      // for reasons I do not understand.
-      // testPattern(
-      //   assert,
-      //   layout,
-      //   event,
-      //   tokens,
-      //   "%d{ISO8601_WITH_TZ_OFFSET}",
-      //   "2010-12-05T03:18:30.045+1000"
-      // );
+      testPattern(
+        assert,
+        layout,
+        event,
+        tokens,
+        "%d{ISO8601_WITH_TZ_OFFSET}",
+        "2010-12-05T14:18:30.045+10:00"
+      );
 
       testPattern(
         assert,
         layout,
         event,
         tokens,
-        "%d{ABSOLUTE}",
+        "%d{ABSOLUTE}", // deprecated
         "14:18:30.045"
       );
       testPattern(
@@ -436,9 +434,27 @@ test("log4js layouts", batch => {
         layout,
         event,
         tokens,
-        "%d{DATE}",
+        "%d{ABSOLUTETIME}",
+        "14:18:30.045"
+      );
+
+      testPattern(
+        assert,
+        layout,
+        event,
+        tokens,
+        "%d{DATE}", // deprecated
         "05 12 2010 14:18:30.045"
       );
+      testPattern(
+        assert,
+        layout,
+        event,
+        tokens,
+        "%d{DATETIME}",
+        "05 12 2010 14:18:30.045"
+      );
+
       testPattern(
         assert,
         layout,
@@ -617,7 +633,15 @@ test("log4js layouts", batch => {
         layout,
         event,
         tokens,
-        "%m%n %c{2} at %d{ABSOLUTE} cheese %p%n",
+        "%m%n %c{2} at %d{ABSOLUTE} cheese %p%n", // deprecated
+        `this is a test${EOL} of.tests at 14:18:30.045 cheese DEBUG${EOL}`
+      );
+      testPattern(
+        assert,
+        layout,
+        event,
+        tokens,
+        "%m%n %c{2} at %d{ABSOLUTETIME} cheese %p%n",
         `this is a test${EOL} of.tests at 14:18:30.045 cheese DEBUG${EOL}`
       );
       assert.end();


### PR DESCRIPTION
Fixes #1012