### PR TITLE
Fixes serialise() for NaN, Infinity, -Infinity and undefined

### DIFF
--- a/lib/LoggingEvent.js
+++ b/lib/LoggingEvent.js
@@ -32,40 +32,37 @@ class LoggingEvent {
   }
 
   serialise() {
-    const logData = this.data.map((e) => {
+    return flatted.stringify(this, (key, value) => {
       // JSON.stringify(new Error('test')) returns {}, which is not really useful for us.
       // The following allows us to serialize errors correctly.
       // duck-typing for Error object
-      if (e && e.message && e.stack) {
-        e = Object.assign({ message: e.message, stack: e.stack }, e);
+      if (value && value.message && value.stack) {
+        value = Object.assign({message: value.message, stack: value.stack}, value);
       }
       // JSON.stringify({a: parseInt('abc'), b: 1/0, c: -1/0}) returns {a: null, b: null, c: null}.
       // The following allows us to serialize to NaN, Infinity and -Infinity correctly.
-      else if (typeof e === 'number' && (isNaN(e) || !isFinite(e))) {
-        e = e.toString();
+      else if (typeof value === 'number' && (isNaN(value) || !isFinite(value))) {
+        value = value.toString();
       }
       // JSON.stringify([undefined]) returns [null].
       // The following allows us to serialize to undefined correctly.
-      else if (typeof e === 'undefined') {
-        e = typeof e;
+      else if (typeof value === 'undefined') {
+        value = typeof value;
       }
-      return e;
+      return value;
     });
-    this.data = logData;
-    return flatted.stringify(this);
   }
 
   static deserialise(serialised) {
     let event;
     try {
-      const rehydratedEvent = flatted.parse(serialised);
-      rehydratedEvent.data = rehydratedEvent.data.map((e) => {
-        if (e && e.message && e.stack) {
-          const fakeError = new Error(e);
-          Object.keys(e).forEach((key) => { fakeError[key] = e[key]; });
-          e = fakeError;
+      const rehydratedEvent = flatted.parse(serialised, (key, value) => {
+        if (value && value.message && value.stack) {
+          const fakeError = new Error(value);
+          Object.keys(value).forEach((k) => { fakeError[k] = value[k]; });
+          value = fakeError;
         }
-        return e;
+        return value;
       });
       event = new LoggingEvent(
         rehydratedEvent.categoryName,

--- a/lib/LoggingEvent.js
+++ b/lib/LoggingEvent.js
@@ -35,8 +35,19 @@ class LoggingEvent {
     const logData = this.data.map((e) => {
       // JSON.stringify(new Error('test')) returns {}, which is not really useful for us.
       // The following allows us to serialize errors correctly.
+      // duck-typing for Error object
       if (e && e.message && e.stack) {
         e = Object.assign({ message: e.message, stack: e.stack }, e);
+      }
+      // JSON.stringify({a: parseInt('abc'), b: 1/0, c: -1/0}) returns {a: null, b: null, c: null}.
+      // The following allows us to serialize to NaN, Infinity and -Infinity correctly.
+      else if (typeof e === 'number' && (isNaN(e) || !isFinite(e))) {
+        e = e.toString();
+      }
+      // JSON.stringify([undefined]) returns [null].
+      // The following allows us to serialize to undefined correctly.
+      else if (typeof e === 'undefined') {
+        e = typeof e;
       }
       return e;
     });

--- a/lib/LoggingEvent.js
+++ b/lib/LoggingEvent.js
@@ -41,7 +41,7 @@ class LoggingEvent {
       }
       // JSON.stringify({a: parseInt('abc'), b: 1/0, c: -1/0}) returns {a: null, b: null, c: null}.
       // The following allows us to serialize to NaN, Infinity and -Infinity correctly.
-      else if (typeof value === 'number' && (isNaN(value) || !isFinite(value))) {
+      else if (typeof value === 'number' && (Number.isNaN(value) || !Number.isFinite(value))) {
         value = value.toString();
       }
       // JSON.stringify([undefined]) returns [null].

--- a/test/tap/LoggingEvent-test.js
+++ b/test/tap/LoggingEvent-test.js
@@ -5,7 +5,7 @@ const levels = require("../../lib/levels");
 
 test("LoggingEvent", batch => {
   batch.test("should serialise to flatted", t => {
-    const event = new LoggingEvent("cheese", levels.DEBUG, ["log message", parseInt("abc"), 1/0, -1/0, undefined], {
+    const event = new LoggingEvent("cheese", levels.DEBUG, ["log message", parseInt("abc", 10), 1/0, -1/0, undefined], {
       user: "bob"
     });
     // set the event date to a known value

--- a/test/tap/LoggingEvent-test.js
+++ b/test/tap/LoggingEvent-test.js
@@ -5,7 +5,7 @@ const levels = require("../../lib/levels");
 
 test("LoggingEvent", batch => {
   batch.test("should serialise to flatted", t => {
-    const event = new LoggingEvent("cheese", levels.DEBUG, ["log message"], {
+    const event = new LoggingEvent("cheese", levels.DEBUG, ["log message", parseInt("abc"), 1/0, -1/0, undefined], {
       user: "bob"
     });
     // set the event date to a known value
@@ -14,8 +14,12 @@ test("LoggingEvent", batch => {
     t.equal(rehydratedEvent.startTime, "2018-02-04T18:30:23.010Z");
     t.equal(rehydratedEvent.categoryName, "cheese");
     t.equal(rehydratedEvent.level.levelStr, "DEBUG");
-    t.equal(rehydratedEvent.data.length, 1);
+    t.equal(rehydratedEvent.data.length, 5);
     t.equal(rehydratedEvent.data[0], "log message");
+    t.equal(rehydratedEvent.data[1], "NaN");
+    t.equal(rehydratedEvent.data[2], "Infinity");
+    t.equal(rehydratedEvent.data[3], "-Infinity");
+    t.equal(rehydratedEvent.data[4], "undefined");
     t.equal(rehydratedEvent.context.user, "bob");
     t.end();
   });


### PR DESCRIPTION
Fixes #1187 

## Affected Components
Only affects clustering, multiprocessAppender, and tcpAppender.
These three will `serialise()` to `String` to transmit for the receiver to `deserialise()`.

Due to `JSON.stringify()`, there are some translation loss:
| Code | Object | JSON.stringify() | Fix |
|-|-|-|-|
`{"a": parseInt("abc")}` | `{"a": NaN}` | `{"a": null}` | `{"a": "NaN"}` | 
`{"b": 1/0}` | `{"b": Infinity}` | `{"b": null}` | `{"c": "Infinity"}` |
`{"c": -1/0}` | `{"c": -Infinity}` | `{"c": null}` | `{"c": "-Infinity"}` |
`[undefined]` | `[undefined]` | `[null]` | `["undefined"]` |

While the fix parses them to `String` instead of the `Object`, it does not affect the output in log files.

## Task
- [x] Code change for single level
- [x] Code change for multi level (recursive)
- [x] Add test cases
- [x] Pass ESLint