### PR TITLE
chore(fix): set logger.level on runtime will no longer reset useCallStack

### DIFF
--- a/lib/categories.js
+++ b/lib/categories.js
@@ -141,6 +141,9 @@ configuration.addListener((config) => {
 
 const setup = (config) => {
   categories.clear();
+  if (!config) {
+    return;
+  }
 
   const categoryNames = Object.keys(config.categories);
   categoryNames.forEach((name) => {
@@ -162,7 +165,7 @@ const setup = (config) => {
 };
 
 const init = () => {
-  setup({ categories: { default: { appenders: ['out'], level: 'OFF' } } });
+  setup();
 };
 init();
 
@@ -174,29 +177,27 @@ const configForCategory = (category) => {
     debug(`configForCategory: ${category} exists in config, returning it`);
     return categories.get(category);
   }
+
+  let sourceCategoryConfig;
   if (category.indexOf('.') > 0) {
-    debug(`configForCategory: ${category} has hierarchy, searching for parents`);
-    return configForCategory(category.substring(0, category.lastIndexOf('.')));
+    debug(`configForCategory: ${category} has hierarchy, cloning from parents`);
+    sourceCategoryConfig = { ...configForCategory(category.substring(0, category.lastIndexOf('.'))) };
+  } else {
+    if (!categories.has('default')) {
+      setup({ categories: { default: { appenders: ['out'], level: 'OFF' } } });
+    }
+    debug('configForCategory: cloning default category');
+    sourceCategoryConfig = { ...categories.get('default') };
   }
-  debug('configForCategory: returning config for default category');
-  return configForCategory('default');
+  categories.set(category, sourceCategoryConfig);
+  return sourceCategoryConfig;
 };
 
 const appendersForCategory = category => configForCategory(category).appenders;
-const getLevelForCategory = category => configForCategory(category).level;
 
+const getLevelForCategory = category => configForCategory(category).level;
 const setLevelForCategory = (category, level) => {
-  let categoryConfig = categories.get(category);
-  debug(`setLevelForCategory: found ${categoryConfig} for ${category}`);
-  if (!categoryConfig) {
-    const sourceCategoryConfig = configForCategory(category);
-    debug('setLevelForCategory: no config found for category, '
-      + `found ${sourceCategoryConfig} for parents of ${category}`);
-    categoryConfig = { appenders: sourceCategoryConfig.appenders };
-    categoryConfig.enableCallStack = sourceCategoryConfig.enableCallStack;
-  }
-  categoryConfig.level = level;
-  categories.set(category, categoryConfig);
+  configForCategory(category).level = level;
 };
 
 const getEnableCallStackForCategory = category => configForCategory(category).enableCallStack === true;

--- a/lib/categories.js
+++ b/lib/categories.js
@@ -193,6 +193,7 @@ const setLevelForCategory = (category, level) => {
     debug('setLevelForCategory: no config found for category, '
       + `found ${sourceCategoryConfig} for parents of ${category}`);
     categoryConfig = { appenders: sourceCategoryConfig.appenders };
+    categoryConfig.enableCallStack = sourceCategoryConfig.enableCallStack;
   }
   categoryConfig.level = level;
   categories.set(category, categoryConfig);

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -60,7 +60,7 @@ class Logger {
   get level() {
     return levels.getLevel(
       categories.getLevelForCategory(this.category),
-      levels.TRACE
+      levels.OFF
     );
   }
 


### PR DESCRIPTION
Fixes #1215 