### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/lib/appenders/adapters.js
+++ b/lib/appenders/adapters.js
@@ -9,8 +9,8 @@ function maxFileSizeUnitTransform(maxLogSize) {
     G: 1024 * 1024 * 1024,
   };
   const validUnit = Object.keys(units);
-  const unit = maxLogSize.substr(maxLogSize.length - 1).toLocaleUpperCase();
-  const value = maxLogSize.substring(0, maxLogSize.length - 1).trim();
+  const unit = maxLogSize.slice(-1).toLocaleUpperCase();
+  const value = maxLogSize.slice(0, -1).trim();
 
   if (validUnit.indexOf(unit) < 0 || !Number.isInteger(Number(value))) {
     throw Error(`maxLogSize: "${maxLogSize}" is invalid`);

--- a/lib/appenders/fileSync.js
+++ b/lib/appenders/fileSync.js
@@ -93,7 +93,7 @@ class RollingFileSync {
     }
 
     function index(filename_) {
-      return parseInt(filename_.substring((`${path.basename(filename)}.`).length), 10) || 0;
+      return parseInt(filename_.slice((`${path.basename(filename)}.`).length), 10) || 0;
     }
 
     function byIndex(a, b) {

--- a/lib/appenders/multiprocess.js
+++ b/lib/appenders/multiprocess.js
@@ -40,9 +40,9 @@ function logServer(config, actualAppender, levels) {
       let event;
       logMessage += chunk || '';
       if (logMessage.indexOf(END_MSG) > -1) {
-        event = logMessage.substring(0, logMessage.indexOf(END_MSG));
+        event = logMessage.slice(0, logMessage.indexOf(END_MSG));
         logTheMessage(event);
-        logMessage = logMessage.substring(event.length + END_MSG.length) || '';
+        logMessage = logMessage.slice(event.length + END_MSG.length) || '';
         // check for more, maybe it was a big chunk
         chunkReceived();
       }

--- a/lib/categories.js
+++ b/lib/categories.js
@@ -19,7 +19,7 @@ function inheritFromParent(config, category, categoryName) {
   if (category.inherit === false) return;
   const lastDotIndex = categoryName.lastIndexOf('.');
   if (lastDotIndex < 0) return; // category is not a child
-  const parentCategoryName = categoryName.substring(0, lastDotIndex);
+  const parentCategoryName = categoryName.slice(0, lastDotIndex);
   let parentCategory = config.categories[parentCategoryName];
 
 
@@ -181,7 +181,7 @@ const configForCategory = (category) => {
   let sourceCategoryConfig;
   if (category.indexOf('.') > 0) {
     debug(`configForCategory: ${category} has hierarchy, cloning from parents`);
-    sourceCategoryConfig = { ...configForCategory(category.substring(0, category.lastIndexOf('.'))) };
+    sourceCategoryConfig = { ...configForCategory(category.slice(0, category.lastIndexOf('.'))) };
   } else {
     if (!categories.has('default')) {
       setup({ categories: { default: { appenders: ['out'], level: 'OFF' } } });

--- a/lib/layouts.js
+++ b/lib/layouts.js
@@ -156,7 +156,7 @@ function patternLayout(pattern, tokens) {
           break;
         case 'ABSOLUTE':
           process.emitWarning(
-            "Pattern %d{ABSOLUTE} is deprecated in favor of %d{ABSOLUTETIME}. " + 
+            "Pattern %d{ABSOLUTE} is deprecated in favor of %d{ABSOLUTETIME}. " +
             "Please use %d{ABSOLUTETIME} instead.",
             "DeprecationWarning", "log4js-node-DEP0003"
           );
@@ -301,7 +301,7 @@ function patternLayout(pattern, tokens) {
   function truncate(truncation, toTruncate) {
     let len;
     if (truncation) {
-      len = parseInt(truncation.substr(1), 10);
+      len = parseInt(truncation.slice(1), 10);
       // negative truncate length means truncate from end of string
       return len > 0 ? toTruncate.slice(0, len) : toTruncate.slice(len);
     }
@@ -313,7 +313,7 @@ function patternLayout(pattern, tokens) {
     let len;
     if (padding) {
       if (padding.charAt(0) === '-') {
-        len = parseInt(padding.substr(1), 10);
+        len = parseInt(padding.slice(1), 10);
         // Right pad with spaces
         while (toPad.length < len) {
           toPad += ' ';
@@ -358,7 +358,7 @@ function patternLayout(pattern, tokens) {
         const replacement = replaceToken(conversionCharacter, loggingEvent, specifier);
         formattedString += truncateAndPad(replacement, truncation, padding);
       }
-      searchString = searchString.substr(result.index + result[0].length);
+      searchString = searchString.slice(result.index + result[0].length);
     }
     return formattedString;
   };

--- a/test/tap/layouts-test.js
+++ b/test/tap/layouts-test.js
@@ -456,7 +456,7 @@ test("log4js layouts", batch => {
         "2010-12-05T14:18:30.045+10:00"
       );
 
-      const DEP0003 = debugLogs.filter((e) => e.indexOf("log4js-node-DEP0003") > -1).length;    
+      const DEP0003 = debugLogs.filter((e) => e.indexOf("log4js-node-DEP0003") > -1).length;
       testPattern(
         assert,
         layout,
@@ -479,7 +479,7 @@ test("log4js layouts", batch => {
         "14:18:30.045"
       );
 
-      const DEP0004 = debugLogs.filter((e) => e.indexOf("log4js-node-DEP0004") > -1).length;    
+      const DEP0004 = debugLogs.filter((e) => e.indexOf("log4js-node-DEP0004") > -1).length;
       testPattern(
         assert,
         layout,
@@ -585,7 +585,7 @@ test("log4js layouts", batch => {
     });
 
     t.test("%f should accept truncation and padding", assert => {
-      testPattern(assert, layout, event, tokens, "%.5f", fileName.substring(0, 5));
+      testPattern(assert, layout, event, tokens, "%.5f", fileName.slice(0, 5));
       testPattern(assert, layout, event, tokens, "%20f{1}", "     layouts-test.js");
       testPattern(assert, layout, event, tokens, "%30.30f{2}", `           ${  path.join("tap","layouts-test.js")}`);
       testPattern(assert, layout, event, tokens, "%10.-5f{1}", "     st.js");

--- a/test/tap/multiprocess-test.js
+++ b/test/tap/multiprocess-test.js
@@ -302,8 +302,8 @@ test("Multiprocess Appender", async batch => {
           data: ["an error message"]
         })}__LOG4JS__`
       );
-      net.cbs.data(logString.substring(0, 10));
-      net.cbs.data(logString.substring(10));
+      net.cbs.data(logString.slice(0, 10));
+      net.cbs.data(logString.slice(10));
       net.cbs.data(logString + logString + logString);
       net.cbs.end(
         `${flatted.stringify({

--- a/test/tap/tcp-appender-test.js
+++ b/test/tap/tcp-appender-test.js
@@ -306,11 +306,12 @@ test("TCP Appender", batch => {
       fakeNet.cbs.drain();
       assert.equal(fakeNet.data.length, previousLength + 1);
       const raw = fakeNet.data[fakeNet.data.length - 1];
+      const offset = raw.indexOf('__LOG4JS__');
       assert.ok(
-        flatted.parse(raw.substring(0, raw.indexOf('__LOG4JS__'))).data[0].stack,
+        flatted.parse(raw.slice(0, offset !== -1 ? offset : 0)).data[0].stack,
         `Expected:\n\n${fakeNet.data[6]}\n\n to have a 'data[0].stack' property`
       );
-      const actual = flatted.parse(raw.substring(0, raw.indexOf('__LOG4JS__'))).data[0].stack;
+      const actual = flatted.parse(raw.slice(0, offset !== -1 ? offset : 0)).data[0].stack;
       assert.match(actual, /^Error: Error test/);
       assert.end();
     });


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated. While [String.prototype.substring()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring) isn't deprecated I replaced it with `slice()` as well.  `slice()` is generally a bit faster (and uses less bites as the name is shorter) and this way we don't have 2 functions which nearly do the same thing in the code.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.