### PR TITLE
feat: tilde expansion for filename

### DIFF
--- a/lib/appenders/file.js
+++ b/lib/appenders/file.js
@@ -31,6 +31,10 @@ function fileAppender(file, layout, logSize, numBackups, options, timezoneOffset
     throw new Error(`Invalid filename: ${file}`);
   } else if (file.endsWith(path.sep)) {
     throw new Error(`Filename is a directory: ${file}`);
+  } else {
+    // handle ~ expansion: https://github.com/nodejs/node/issues/684
+    // exclude ~ and ~filename as these can be valid files
+    file = file.replace(new RegExp(`^~(?=${path.sep}.+)`), os.homedir());
   }
   file = path.normalize(file);
   numBackups = (!numBackups && numBackups !== 0) ? 5 : numBackups;

--- a/lib/appenders/fileSync.js
+++ b/lib/appenders/fileSync.js
@@ -166,6 +166,10 @@ function fileAppender(file, layout, logSize, numBackups, options, timezoneOffset
     throw new Error(`Invalid filename: ${file}`);
   } else if (file.endsWith(path.sep)) {
     throw new Error(`Filename is a directory: ${file}`);
+  } else {
+    // handle ~ expansion: https://github.com/nodejs/node/issues/684
+    // exclude ~ and ~filename as these can be valid files
+    file = file.replace(new RegExp(`^~(?=${path.sep}.+)`), os.homedir());
   }
   file = path.normalize(file);
   numBackups = (!numBackups && numBackups !== 0) ? 5 : numBackups;


### PR DESCRIPTION
1. `~` in `~/` or `~\` will be expanded to `os.homedir()`
   (`~` and `~filename` unaffected as these are valid filenames) 