### PR TITLE
feat: `logger.log()` to be synonym of `logger.info()`

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -82,9 +82,15 @@ class Logger {
   log(level, ...args) {
     let logLevel = levels.getLevel(level);
     if (!logLevel) {
-      this._log(levels.WARN, ['log4js:logger.log: invalid value for log-level as first parameter given:', level]);
+      // allow LOG to be synonym of INFO
+      if ((level && level.trim().indexOf(" ") !== -1) || args.length === 0) {
+        args = [level, ...args];
+      } else {
+        this._log(levels.WARN, ['log4js:logger.log: invalid value for log-level as first parameter given:', level]);
+        args = [`[${level}]`, ...args];
+      }
+      // fallback to INFO
       logLevel = levels.INFO;
-      args = [level, ...args];
     }
     if (this.isLevelEnabled(logLevel)) {
       this._log(logLevel, args);

--- a/test/tap/newLevel-test.js
+++ b/test/tap/newLevel-test.js
@@ -232,9 +232,13 @@ test("../../lib/logger", batch => {
 
     const logger = log4js.getLogger();
 
+    // fallback behavior
     logger.log("LEVEL_DOES_NOT_EXIST", "Event 1");
-    logger.log(log4js.levels.getLevel("LEVEL_DOES_NOT_EXIST"), "Event 2");
+    logger.log(log4js.levels.getLevel("LEVEL_DOES_NOT_EXIST"), "Event 2", "2 Text");
+
+    // synonym behavior
     logger.log("Event 3");
+    logger.log("Event 4", "4 Text");
 
     const events = recording.replay();
 
@@ -242,21 +246,23 @@ test("../../lib/logger", batch => {
     t.equal(events[0].data[0], "log4js:logger.log: invalid value for log-level as first parameter given:");
     t.equal(events[0].data[1], "LEVEL_DOES_NOT_EXIST");
     t.equal(events[1].level.toString(), "INFO", "should fall back to INFO");
-    t.equal(events[1].data[0], "LEVEL_DOES_NOT_EXIST");
+    t.equal(events[1].data[0], "[LEVEL_DOES_NOT_EXIST]");
     t.equal(events[1].data[1], "Event 1");
 
     t.equal(events[2].level.toString(), "WARN", "should log warning");
     t.equal(events[2].data[0], "log4js:logger.log: invalid value for log-level as first parameter given:");
     t.equal(events[2].data[1], undefined);
     t.equal(events[3].level.toString(), "INFO", "should fall back to INFO");
-    t.equal(events[3].data[0], undefined);
+    t.equal(events[3].data[0], "[undefined]");
     t.equal(events[3].data[1], "Event 2");
+    t.equal(events[3].data[2], "2 Text");
 
-    t.equal(events[4].level.toString(), "WARN", "should log warning");
-    t.equal(events[4].data[0], "log4js:logger.log: invalid value for log-level as first parameter given:");
-    t.equal(events[4].data[1], "Event 3");
-    t.equal(events[5].level.toString(), "INFO", "should fall back to INFO");
-    t.equal(events[5].data[0], "Event 3");
+    t.equal(events[4].level.toString(), "INFO", "LOG is synonym of INFO");
+    t.equal(events[4].data[0], "Event 3");
+
+    t.equal(events[5].level.toString(), "INFO", "LOG is synonym of INFO");
+    t.equal(events[5].data[0], "Event 4");
+    t.equal(events[5].data[1], "4 Text");
 
     t.end();
   });


### PR DESCRIPTION
1. `logger.log()` will behave as a synonym for `logger.info()` as much as possible based on the method signature
2. No regression for `logger.log()`'s existing private function (which has a different method signature)
3. If it is unable to determine if it should be a synonym from the method signature, it will `WARN` and fallback to `INFO`