### PR TITLE
fix: fs.appendFileSync should use flag instead of flags

### DIFF
--- a/lib/appenders/fileSync.js
+++ b/lib/appenders/fileSync.js
@@ -41,7 +41,7 @@ function touchFile(file, options) {
   mkdir(path.dirname(file));
 
   // try to throw EISDIR, EROFS, EACCES
-  fs.appendFileSync(file, "", { mode: options.mode, flags: options.flag });
+  fs.appendFileSync(file, "", { mode: options.mode, flag: options.flags });
 }
 
 class RollingFileSync {


### PR DESCRIPTION
Strangely, `fs.appendFileSync` uses `flag` but `fs.createWriteStream` uses `flags`.

It's somewhat inconsistent throughout the Node.js documentation:
https://nodejs.org/api/fs.html