### PR TITLE
feat: adding function(req, res) support to connectLogger options->nol…

### DIFF
--- a/docs/connect-logger.md
+++ b/docs/connect-logger.md
@@ -30,7 +30,7 @@ The log4js.connectLogger supports the passing of an options object that can be u
 
 - log level
 - log format string or function (the same as the connect/express logger)
-- nolog expressions (represented as a string, regexp, or array)
+- nolog expressions (represented as a string, regexp, array, or function(req, res))
 - status code rulesets
 
 For example:
@@ -97,7 +97,7 @@ app.use(
 );
 ```
 
-The log4js.connectLogger also supports a nolog option where you can specify a string, regexp, or array to omit certain log messages. Example of 1.2 below.
+The log4js.connectLogger also supports a nolog option where you can specify a string, regexp, array, or function(req, res) to omit certain log messages. Example of 1.2 below.
 
 ```javascript
 app.use(
@@ -105,6 +105,18 @@ app.use(
     level: "auto",
     format: ":method :url",
     nolog: "\\.gif|\\.jpg$",
+  })
+);
+```
+
+or
+
+```javascript
+app.use(
+  log4js.connectLogger(logger, {
+    level: "auto",
+    format: ":method :url",
+    nolog: (req, res) => res.statusCode < 400,
   })
 );
 ```

--- a/lib/connect-logger.js
+++ b/lib/connect-logger.js
@@ -215,7 +215,7 @@ function matchRules(statusCode, currentLevel, ruleSet) {
  *
  *   - `format`        Format string, see below for tokens
  *   - `level`         A log4js levels instance. Supports also 'auto'
- *   - `nolog`         A string or RegExp to exclude target logs
+ *   - `nolog`         A string or RegExp to exclude target logs or function(req, res): boolean
  *   - `statusRules`   A array of rules for setting specific logging levels base on status codes
  *   - `context`       Whether to add a response of express to the context
  *

--- a/lib/connect-logger.js
+++ b/lib/connect-logger.js
@@ -248,14 +248,18 @@ module.exports = function getLogger(logger4js, options) {
   const thisLogger = logger4js;
   let level = levels.getLevel(options.level, levels.INFO);
   const fmt = options.format || DEFAULT_FORMAT;
-  const nolog = createNoLogCondition(options.nolog);
 
   return (req, res, next) => {
     // mount safety
     if (req._logging) return next();
 
     // nologs
-    if (nolog && nolog.test(req.originalUrl)) return next();
+    if (typeof options.nolog === 'function') {
+      if (options.nolog(req, res) === true) return next();
+    } else {
+      const nolog = createNoLogCondition(options.nolog);
+      if (nolog && nolog.test(req.originalUrl)) return next();
+    }
 
     if (thisLogger.isLevelEnabled(level) || options.level === 'auto') {
       const start = new Date();


### PR DESCRIPTION
#1278 Adding connectLogger options.nolog -> (req, res).
Example:
```js
const connectLogger = log4js.connectLogger(logger, { nolog: (req, res) => res.statusCode < 400 });
```