### PR TITLE
Idempotent logging on browser

### DIFF
--- a/lib/clusteringBrowser.js
+++ b/lib/clusteringBrowser.js
@@ -1,0 +1,19 @@
+/* istanbul ignore file */
+// This is used in browsers only and is designed to allow the rest of
+// log4js to continue as if `clustering.js` is in use.
+const isMaster = () => true;
+
+const listeners = [];
+
+const sendToListeners = (logEvent) => {
+  listeners.forEach((l) => l(logEvent));
+};
+
+module.exports = {
+  onlyOnMaster: (fn, notMaster) => (isMaster() ? fn() : notMaster),
+  isMaster,
+  send: sendToListeners,
+  onMessage: (listener) => {
+    listeners.push(listener);
+  },
+};

--- a/package.json
+++ b/package.json
@@ -73,7 +73,13 @@
     "typescript": "^4.9.5"
   },
   "browser": {
-    "os": false
+    "os": false,
+    "streamroller": false,
+    "./lib/clustering.js": "./lib/clusteringBrowser.js",
+    "./lib/appenders/dateFile.js": "./lib/appenders/ignoreBrowser.js",
+    "./lib/appenders/file.js": "./lib/appenders/ignoreBrowser.js",
+    "./lib/appenders/fileSync.js": "./lib/appenders/ignoreBrowser.js",
+    "./lib/appenders/multiFile.js": "./lib/appenders/ignoreBrowser.js"
   },
   "prettier": {
     "trailingComma": "es5",


### PR DESCRIPTION
Certain modules do not exist in a browser environment, e.g. cluster, file/os/path, etc.

In that environment, file-based appenders are effectively disabled by this commit, without modifying the source directly.

The `clustering.js` file is still required, but this commit essentially makes it a no-op, again without modifying the source directly.

This addresses #968 and supersedes PR 1023 https://github.com/log4js-node/log4js-node/pull/1023 
