### PR TITLE
fix(7922e82): regex for stacktrace

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -7,7 +7,7 @@ const clustering = require('./clustering');
 const categories = require('./categories');
 const configuration = require('./configuration');
 
-const stackReg = /^(?:\s*) at (?:(.+) \()?(?:([^(]+?):(\d+):(\d+))\)?$/;
+const stackReg = /^(?:\s*)at (?:(.+) \()?(?:([^(]+?):(\d+):(\d+))\)?$/;
 /**
  * The top entry is the Error
  */


### PR DESCRIPTION
Regression since [6.8.0](https://github.com/log4js-node/log4js-node/milestone/92) from #1363 at commit 7922e82.