### PR TITLE
fix(#1388): regex for stacktrace

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -7,7 +7,7 @@ const clustering = require('./clustering');
 const categories = require('./categories');
 const configuration = require('./configuration');
 
-const stackReg = /^(?:\s*)at (?:(.+) \()?(?:([^(]+?):(\d+):(\d+))\)?$/;
+const stackReg = /^(?:\s*)at (?:(.+) \()?(?:(.+?):(\d+):(\d+))\)?$/;
 /**
  * The top entry is the Error
  */

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -7,7 +7,46 @@ const clustering = require('./clustering');
 const categories = require('./categories');
 const configuration = require('./configuration');
 
-const stackReg = /^(?:\s*)at (?:(.+) \()?(?:(.+?):(\d+):(\d+))\)?$/;
+function isDigits(value) {
+  return /^\d+$/.test(value);
+}
+
+function parseStackLine(line) {
+  let stackLine = line.trimStart();
+  if (!stackLine.startsWith('at ')) return null;
+
+  stackLine = stackLine.slice(3);
+  if (stackLine.endsWith(')')) {
+    stackLine = stackLine.slice(0, -1);
+  }
+
+  const columnSeparator = stackLine.lastIndexOf(':');
+  if (columnSeparator === -1) return null;
+
+  const columnNumber = stackLine.slice(columnSeparator + 1);
+  if (!isDigits(columnNumber)) return null;
+
+  const lineSeparator = stackLine.lastIndexOf(':', columnSeparator - 1);
+  if (lineSeparator === -1) return null;
+
+  const lineNumber = stackLine.slice(lineSeparator + 1, columnSeparator);
+  if (!isDigits(lineNumber)) return null;
+
+  const location = stackLine.slice(0, lineSeparator);
+  const callerSeparator = location.lastIndexOf(' (');
+
+  if (callerSeparator === -1) {
+    return ['', location, lineNumber, columnNumber];
+  }
+
+  return [
+    location.slice(0, callerSeparator),
+    location.slice(callerSeparator + 2),
+    lineNumber,
+    columnNumber,
+  ];
+}
+
 /**
  * The top entry is the Error
  */
@@ -34,16 +73,16 @@ function defaultParseCallStack(
       // Should we try a previous index if skipIdx was set?
       return null;
     }
-    const lineMatch = stackReg.exec(stacklines[0]);
+    const lineMatch = parseStackLine(stacklines[0]);
     /* istanbul ignore else: failsafe */
-    if (lineMatch && lineMatch.length === 5) {
+    if (lineMatch && lineMatch.length === 4) {
       // extract class, function and alias names
       let className = '';
       let functionName = '';
       let functionAlias = '';
-      if (lineMatch[1] && lineMatch[1] !== '') {
+      if (lineMatch[0] && lineMatch[0] !== '') {
         // WARN: this will unset alias if alias is not present.
-        [functionName, functionAlias] = lineMatch[1]
+        [functionName, functionAlias] = lineMatch[0]
           .replace(/[[\]]/g, '')
           .split(' as ');
         functionAlias = functionAlias || '';
@@ -53,14 +92,14 @@ function defaultParseCallStack(
       }
 
       return {
-        fileName: lineMatch[2],
-        lineNumber: parseInt(lineMatch[3], 10),
-        columnNumber: parseInt(lineMatch[4], 10),
+        fileName: lineMatch[1],
+        lineNumber: parseInt(lineMatch[2], 10),
+        columnNumber: parseInt(lineMatch[3], 10),
         callStack: stacklines.join('\n'),
         className,
         functionName,
         functionAlias,
-        callerName: lineMatch[1] || '',
+        callerName: lineMatch[0] || '',
       };
       // eslint-disable-next-line no-else-return
     } else {

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -164,6 +164,8 @@ class Logger {
     debug(`sending log data (${level}) to appenders`);
     const error = data.find((item) => item instanceof Error);
     let callStack;
+    const usingDefaultParseCallStack =
+      this.parseCallStack === defaultParseCallStack;
     if (this.useCallStack) {
       try {
         if (error) {
@@ -183,6 +185,9 @@ class Logger {
             defaultErrorCallStackSkip +
             baseCallStackSkip
         );
+      if (usingDefaultParseCallStack && !callStack) {
+        callStack = undefined;
+      }
     }
     const loggingEvent = new LoggingEvent(
       this.category,

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -11,8 +11,21 @@ function isDigits(value) {
   return /^\d+$/.test(value);
 }
 
+function trimStart(value) {
+  if (typeof value.trimStart === 'function') {
+    return value.trimStart();
+  }
+
+  // fallback for Node.js 8, which does not support String.prototype.trimStart
+  let index = 0;
+  while (value[index] === ' ' || value[index] === '\t') {
+    index += 1;
+  }
+  return value.slice(index);
+}
+
 function parseStackLine(line) {
-  let stackLine = line.trimStart();
+  let stackLine = trimStart(line);
   if (!stackLine.startsWith('at ')) return null;
 
   stackLine = stackLine.slice(3);

--- a/test/tap/logger-test.js
+++ b/test/tap/logger-test.js
@@ -351,6 +351,23 @@ test('../../lib/logger', (batch) => {
     t.end();
   });
 
+  batch.test('parseCallStack rejects malformed stack lines', (t) => {
+    const logger = new Logger('stack');
+    logger.useCallStack = true;
+
+    [
+      '    not a stack line',
+      `    at ${'a (a'.repeat(1000)}`,
+      '    at file:1',
+      '    at file:1:x',
+      '    at file:x:1',
+    ].forEach((stack) => {
+      t.equal(logger.parseCallStack({ stack }, 0), null);
+    });
+
+    t.end();
+  });
+
   batch.test(
     'should log without location when default call stack parsing fails',
     (t) => {

--- a/test/tap/logger-test.js
+++ b/test/tap/logger-test.js
@@ -45,6 +45,7 @@ const testConfig = {
 test('../../lib/logger', (batch) => {
   batch.beforeEach((done) => {
     events.length = 0;
+    messages.length = 0;
     testConfig.level = levels.TRACE;
     if (typeof done === 'function') {
       done();
@@ -331,6 +332,52 @@ test('../../lib/logger', (batch) => {
     t.equal(results.functionName, 'bar');
     t.equal(results.functionAlias, '');
     t.equal(results.callerName, 'Foo.bar');
+
+    const callStack6 =
+      '    at RootLayout (webpack-internal:///(sc_server)/./app/layout.tsx:44:81)\n    at ContextifyScript.Script.runInThisContext (vm.js:50:33)'; // eslint-disable-line max-len
+    results = logger.parseCallStack({ stack: callStack6 }, 0);
+    t.ok(results);
+    t.equal(results.className, '');
+    t.equal(results.functionName, 'RootLayout');
+    t.equal(results.functionAlias, '');
+    t.equal(results.callerName, 'RootLayout');
+    t.equal(
+      results.fileName,
+      'webpack-internal:///(sc_server)/./app/layout.tsx'
+    );
+    t.equal(results.lineNumber, 44);
+    t.equal(results.columnNumber, 81);
+
+    t.end();
+  });
+
+  batch.test(
+    'should log without location when default call stack parsing fails',
+    (t) => {
+      const logger = new Logger('stack');
+      logger.level = 'debug';
+      logger.useCallStack = true;
+      logger.callStackLinesToSkip = 1000;
+
+      t.doesNotThrow(() => logger.debug('test with invalid callStack'));
+      t.equal(events.length, 1);
+      t.notMatch(events[0], { callStack: String });
+
+      t.end();
+    }
+  );
+
+  batch.test('should throw when custom call stack parsing fails', (t) => {
+    const logger = new Logger('stack');
+    logger.level = 'debug';
+    logger.useCallStack = true;
+    logger.setParseCallStackFunction(() => null);
+
+    t.throws(
+      () => logger.debug('test with invalid custom callStack'),
+      new TypeError('Invalid location type passed to LoggingEvent constructor')
+    );
+    t.equal(events.length, 0);
 
     t.end();
   });

--- a/test/tap/logger-test.js
+++ b/test/tap/logger-test.js
@@ -368,6 +368,49 @@ test('../../lib/logger', (batch) => {
     t.end();
   });
 
+  batch.test('parseCallStack supports Node.js 8 trimStart fallback', (t) => {
+    const logger = new Logger('stack');
+    const line = '    at Foo.bar (repl:1:14)';
+    const stackLine = {
+      0: line[0],
+      1: line[1],
+      2: line[2],
+      3: line[3],
+      slice: (...args) => line.slice(...args),
+    };
+    const stack = {
+      split: () => [stackLine],
+    };
+    const results = logger.parseCallStack({ stack }, 0);
+
+    t.ok(results);
+    t.equal(results.callerName, 'Foo.bar');
+    t.equal(results.fileName, 'repl');
+    t.equal(results.lineNumber, 1);
+    t.equal(results.columnNumber, 14);
+
+    t.end();
+  });
+
+  batch.test('parseCallStack uses trimStart when available', (t) => {
+    const logger = new Logger('stack');
+    const stackLine = {
+      trimStart: () => 'at Foo.bar (repl:1:14)',
+    };
+    const stack = {
+      split: () => [stackLine],
+    };
+    const results = logger.parseCallStack({ stack }, 0);
+
+    t.ok(results);
+    t.equal(results.callerName, 'Foo.bar');
+    t.equal(results.fileName, 'repl');
+    t.equal(results.lineNumber, 1);
+    t.equal(results.columnNumber, 14);
+
+    t.end();
+  });
+
   batch.test(
     'should log without location when default call stack parsing fails',
     (t) => {


### PR DESCRIPTION
Regression since [6.9.1](https://github.com/log4js-node/log4js-node/milestone/94) from #1378.