### PR TITLE
fix: enable method chaining for after writeHead

### DIFF
--- a/lib/connect-logger.js
+++ b/lib/connect-logger.js
@@ -273,6 +273,7 @@ module.exports = function getLogger(logger4js, options) {
 
         res.__statusCode = code;
         res.__headers = headers || {};
+        return res;
       };
 
       // hook on end request to emit the log entry of the HTTP request.

--- a/test/tap/connect-context-test.js
+++ b/test/tap/connect-context-test.js
@@ -58,6 +58,7 @@ class MockResponse extends EE {
 
   writeHead(code /* , headers */) {
     this.statusCode = code;
+    return this;
   }
 }
 

--- a/test/tap/connect-logger-test.js
+++ b/test/tap/connect-logger-test.js
@@ -58,6 +58,7 @@ class MockResponse extends EE {
 
   writeHead(code /* , headers */) {
     this.statusCode = code;
+    return this;
   }
 }
 
@@ -87,8 +88,7 @@ function request(
     next = () => {};
   }
   cl(req, res, next);
-  res.writeHead(code, resHeaders);
-  res.end('chunk', 'encoding');
+  res.writeHead(code, resHeaders).end('chunk', 'encoding');
 }
 
 test('log4js connect logger', (batch) => {

--- a/test/tap/connect-nolog-test.js
+++ b/test/tap/connect-nolog-test.js
@@ -49,6 +49,7 @@ class MockResponse extends EE {
 
   writeHead(code /* , headers */) {
     this.statusCode = code;
+    return this;
   }
 }
 


### PR DESCRIPTION
writeHead now also returns a reference to the response object as specified here: https://nodejs.org/api/http.html#responsewriteheadstatuscode-statusmessage-headers