### PR TITLE
Fix to do not cut off multiFile appender code by bundler's tree shaking 

### DIFF
--- a/lib/appenders/index.js
+++ b/lib/appenders/index.js
@@ -16,6 +16,7 @@ coreAppenders.set('categoryFilter', require('./categoryFilter'));
 coreAppenders.set('noLogFilter', require('./noLogFilter'));
 coreAppenders.set('file', require('./file'));
 coreAppenders.set('dateFile', require('./dateFile'));
+coreAppenders.set('multiFile', require('./multiFile'));
 coreAppenders.set('fileSync', require('./fileSync'));
 coreAppenders.set('tcp', require('./tcp'));
 

--- a/lib/appenders/index.js
+++ b/lib/appenders/index.js
@@ -14,11 +14,14 @@ coreAppenders.set('stderr', require('./stderr'));
 coreAppenders.set('logLevelFilter', require('./logLevelFilter'));
 coreAppenders.set('categoryFilter', require('./categoryFilter'));
 coreAppenders.set('noLogFilter', require('./noLogFilter'));
+coreAppenders.set('recording', require('./recording'));
 coreAppenders.set('file', require('./file'));
 coreAppenders.set('dateFile', require('./dateFile'));
 coreAppenders.set('multiFile', require('./multiFile'));
+coreAppenders.set('multiprocess', require('./multiprocess'));
 coreAppenders.set('fileSync', require('./fileSync'));
 coreAppenders.set('tcp', require('./tcp'));
+coreAppenders.set('tcp-server', require('./tcp-server'));
 
 const appenders = new Map();
 


### PR DESCRIPTION
PR to fix #1395 , some appender types are missing from `coreAppenders` so tried to add.

I don't know correct build/test process but anyway my branch worked with the reproduce code in the issue.


#1411 may have same cause.