### PR TITLE
Update typescript usage in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ There's also [an example application](https://github.com/log4js-node/log4js-exam
 ## TypeScript
 
 ```ts
-import * as log4js from "log4js";
+import log4js from "log4js";
 log4js.configure({
   appenders: { cheese: { type: "file", filename: "cheese.log" } },
   categories: { default: { appenders: ["cheese"], level: "error" } },


### PR DESCRIPTION
PR to fix https://github.com/log4js-node/log4js-node/issues/1410
When using `import * as log4js from 'log4js';` in TypeScript, a `TypeError: log4js.getLogger is not a function";` would be thrown.
`import log4js from "log4js";` is the correct usage.