### PR TITLE
upgrade flatted dep to 3.4.2 to fix vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2072,9 +2072,9 @@
       }
     },
     "flatted": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
-      "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ=="
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA=="
     },
     "for-each": {
       "version": "0.3.3",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "date-format": "^4.0.14",
     "debug": "^4.3.4",
-    "flatted": "^3.2.7",
+    "flatted": "^3.4.2",
     "rfdc": "^1.3.0",
     "streamroller": "^3.1.5"
   },


### PR DESCRIPTION
Fix Issue https://github.com/log4js-node/log4js-node/issues/1446

In package.json, we need `flatted`:

```json
  "dependencies": {
    "date-format": "^4.0.14",
    "debug": "^4.3.4",
    "flatted": "^3.2.7",
    "rfdc": "^1.3.0",
    "streamroller": "^3.1.5"
  },
```

The version 3.2.7 has the known vulnerability [CVE-2026-32141](https://www.cve.org/CVERecord?id=CVE-2026-32141).

upgrade it to 3.4.2
